### PR TITLE
Fix missing username when saving posts

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -70,6 +70,7 @@ export default function HomeScreen() {
         {
           content: postText,
           user_id: user.id,
+          username: profile.display_name || profile.username,
         },
       ])
       .select()


### PR DESCRIPTION
## Summary
- include `username` when inserting posts

## Testing
- `npx tsc --noEmit` *(fails: missing dependencies)*