### PR TITLE
Fix posts insertion error for missing username column

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -64,16 +64,33 @@ export default function HomeScreen() {
     setPosts((prev) => [newPost, ...prev]);
     setPostText('');
 
-    const { data, error } = await supabase
+    const insertPayload = {
+      content: postText,
+      user_id: user.id,
+      username: profile.display_name || profile.username,
+    };
+
+    let { data, error } = await supabase
       .from('posts')
-      .insert([
-        {
-          content: postText,
-          user_id: user.id,
-        },
-      ])
+      .insert([insertPayload])
       .select()
       .single();
+
+    if (error?.code === 'PGRST204') {
+      // Retry without the username column if the schema cache doesn't know it
+      const retry = await supabase
+        .from('posts')
+        .insert([
+          {
+            content: postText,
+            user_id: user.id,
+          },
+        ])
+        .select()
+        .single();
+      data = retry.data;
+      error = retry.error;
+    }
 
     if (!error && data) {
       // Update the optimistic post with the real data from Supabase


### PR DESCRIPTION
## Summary
- include `username` when inserting posts
- retry post creation without `username` if the column doesn't exist

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*