### PR TITLE
Fix profile creation and post insertion

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -27,11 +27,27 @@ export function AuthProvider({ children }) {
 
 
     // Create a new profile with the provided or derived username
-    const { error } = await supabase.from('profiles').insert({
-      id: authUser.id,
-      username: defaultUsername,
-      display_name: defaultDisplayName,
-    });
+    let { error } = await supabase
+      .from('profiles')
+      .upsert(
+        {
+          id: authUser.id,
+          username: defaultUsername,
+          display_name: defaultDisplayName,
+        },
+        { onConflict: 'id' }
+      );
+
+    if (error?.code === 'PGRST204') {
+      // Retry without the display_name column if the schema cache doesn't know it
+      const retry = await supabase
+        .from('profiles')
+        .upsert(
+          { id: authUser.id, username: defaultUsername },
+          { onConflict: 'id' }
+        );
+      error = retry.error;
+    }
 
     // Log any insertion error for easier debugging
     if (error) console.error('Failed to insert profile:', error);
@@ -120,34 +136,10 @@ export function AuthProvider({ children }) {
       return { error };
     }
 
-    const userId = newUser?.id;
-    if (userId) {
-      const { error: insertError } = await supabase.from('profiles').insert({
-        id: userId,
-        username,
-        display_name: username,
-      });
+    // Signing in again ensures we have a session so RLS policies pass
+    const { error: signInErr } = await signIn(email, password);
 
-      if (insertError) {
-        // The insert can fail if policies aren't set up yet
-        console.error('Failed to insert profile on sign up:', insertError);
-
-      }
-
-      // Immediately store the authenticated user and profile
-      setUser(newUser);
-      setProfile({
-        id: userId,
-        username,
-        display_name: username,
-        email: newUser.email,
-      });
-
-      return { error: null };
-    }
-
-    // No userId should rarely happen, but surface an error if it does
-    return { error: { message: 'User ID missing after sign up' } };
+    return { error: signInErr };
   };
 
 


### PR DESCRIPTION
## Summary
- ensure user profiles are upserted, retrying without `display_name` if needed
- sign up now signs the user in so profile creation passes RLS checks
- include the username when inserting posts and retry if schema cache misses

## Testing
- `npx tsc --noEmit` *(fails: cannot find module 'react', etc.)*
