### PR TITLE
Fix 204 response retry logic

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -92,33 +92,29 @@ export default function HomeScreen() {
       .single();
 
     if (error?.code === 'PGRST204') {
-
-      const retry = await supabase
-        .from('posts')
-        .insert([
-          { content: postText, user_id: user.id },
-        ])
-        .select()
-        .single();
-      data = retry.data;
-      error = retry.error;
-
+      // Treat a 204 response as success with no data
+      error = null as any;
     }
 
-    if (!error && data) {
-      // Update the optimistic post with the real data from Supabase
-      setPosts((prev) => {
-        const updated = prev.map((p) =>
-          p.id === newPost.id
-            ? { ...p, id: data.id, created_at: data.created_at }
-            : p
-        );
-        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-        return updated;
-      });
+    if (!error) {
+      if (data) {
+        // Update the optimistic post with the real data from Supabase
+        setPosts((prev) => {
+          const updated = prev.map((p) =>
+            p.id === newPost.id
+              ? { ...p, id: data.id, created_at: data.created_at }
+              : p
+          );
+          AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+          return updated;
+        });
 
-      // Refresh from the server in the background to stay in sync
-      fetchPosts();
+        // Refresh from the server in the background to stay in sync
+        fetchPosts();
+      } else {
+        // No data returned, just refresh to ensure persistence
+        fetchPosts();
+      }
     } else {
       // Remove the optimistic post if it failed to persist
       setPosts((prev) => {
@@ -128,7 +124,7 @@ export default function HomeScreen() {
       });
 
       // Log the failure and surface it to the user
-      console.error('Failed to post:', error);
+      console.error('Failed to post:', error?.message);
       Alert.alert('Post failed', error?.message ?? 'Unable to create post');
     }
   };

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -85,15 +85,8 @@ export default function PostDetailScreen() {
       .single();
 
     if (error?.code === 'PGRST204') {
-      const retry = await supabase
-        .from('replies')
-
-        .insert([{ post_id: post.id, user_id: user.id, content: replyText }])
-
-        .select()
-        .single();
-      data = retry.data;
-      error = retry.error;
+      // Treat a 204 response as success with no data
+      error = null as any;
     }
 
     if (!error) {
@@ -105,7 +98,7 @@ export default function PostDetailScreen() {
       // Whether or not data was returned, refresh from the server so the reply persists
       fetchReplies();
     } else {
-      console.error('Failed to reply:', error);
+      console.error('Failed to reply:', error?.message);
       setReplies(prev => prev.filter(r => r.id !== newReply.id));
 
     }


### PR DESCRIPTION
## Summary
- treat 204 insert results as success without retry
- log only the error message on failures

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise')*