### PR TITLE
Fix replies disappearing after failed post

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, Button, FlatList, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, FlatList, StyleSheet, Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRoute } from '@react-navigation/native';
 
@@ -125,9 +125,9 @@ export default function PostDetailScreen() {
       fetchReplies();
     } else {
       console.error('Failed to reply:', error?.message);
-      setReplies(prev => prev.filter(r => r.id !== newReply.id));
+      Alert.alert('Reply failed', error?.message ?? 'Unable to create reply');
 
-
+      // Keep the optimistic reply so the user doesn't lose their input
     }
   };
 


### PR DESCRIPTION
## Summary
- keep optimistic reply in PostDetailScreen when the server request fails
- show an alert if posting the reply fails

## Testing
- `npm test` *(fails: Missing script)*