### PR TITLE
Merge optimistic replies with fetched data

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -47,13 +47,18 @@ export default function PostDetailScreen() {
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      .select('id, post_id, user_id, content, created_at, profiles(username, display_name)')
+      // fetch only reply fields to avoid missing relationship errors
+      .select('id, post_id, user_id, content, created_at, username')
       .eq('post_id', post.id)
       .order('created_at', { ascending: false });
     if (!error && data) {
       setReplies(prev => {
-        const optimistic = prev.filter(r => r.id.startsWith('temp-'));
-        const merged = [...optimistic, ...(data as Reply[])];
+        // Keep any replies that haven't been synced yet (ids starting with "temp-")
+        const tempReplies = prev.filter(r => r.id.startsWith('temp-'));
+        const merged = [...tempReplies, ...(data as Reply[])];
+        merged.sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
 
         AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
         return merged;
@@ -129,7 +134,7 @@ export default function PostDetailScreen() {
       // Whether or not data was returned, refresh from the server so the reply persists
       fetchReplies();
     } else {
-      console.error('Failed to reply:', error?.message);
+      console.error('Failed to reply:', error);
       Alert.alert('Reply failed', error?.message ?? 'Unable to create reply');
 
       // Keep the optimistic reply so the user doesn't lose their input


### PR DESCRIPTION
## Summary
- keep temporary replies when fetching new ones and sort them
- fetch reply data without the profiles join
- show failure alert without removing optimistic reply

## Testing
- `npm test` *(fails: Missing script)*