### PR TITLE
Merge optimistic replies with fetched data

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -181,7 +181,13 @@ export default function HomeScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, backgroundColor: colors.background },
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    paddingTop: '15%',
+    backgroundColor: colors.background,
+  },
   input: {
     backgroundColor: 'white',
     padding: 10,

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -52,8 +52,9 @@ export default function PostDetailScreen() {
       .order('created_at', { ascending: false });
     if (!error && data) {
       setReplies(prev => {
-        const optimistic = prev.filter(r => r.id.startsWith('temp-'));
-        const merged = [...optimistic, ...(data as Reply[])];
+        // Keep any replies that haven't been synced yet (ids starting with "temp-")
+        const tempReplies = prev.filter(r => r.id.startsWith('temp-'));
+        const merged = [...tempReplies, ...(data as Reply[])];
 
         AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
         return merged;


### PR DESCRIPTION
## Summary
- keep temporary replies when fetching new ones
- show failure alert without removing optimistic reply
- reduce home screen top padding to about 15%

## Testing
- `npm test` *(fails: Missing script)*