### PR TITLE
Reduce spacing between logout and tabs

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -45,7 +45,7 @@ export default function TopTabsNavigator() {
         screenOptions={{
           tabBarStyle: {
             backgroundColor: '#1d152b',
-            marginTop: 65,
+            marginTop: 20,
           },
           tabBarLabelStyle: {
             color: 'white',

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -52,8 +52,9 @@ export default function PostDetailScreen() {
       .order('created_at', { ascending: false });
     if (!error && data) {
       setReplies(prev => {
-        const optimistic = prev.filter(r => r.id.startsWith('temp-'));
-        const merged = [...optimistic, ...(data as Reply[])];
+        // Keep any replies that haven't been synced yet (ids starting with "temp-")
+        const tempReplies = prev.filter(r => r.id.startsWith('temp-'));
+        const merged = [...tempReplies, ...(data as Reply[])];
 
         AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
         return merged;


### PR DESCRIPTION
## Summary
- make the tab bar sit closer to the Logout button by lowering its top margin

## Testing
- `npm test` *(fails: Missing script)*