### PR TITLE
Add blurred translucent tab bar

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
-import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import { createMaterialTopTabNavigator, MaterialTopTabBar, MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
+import { BlurView } from 'expo-blur';
 import {
   View,
   Text,
@@ -13,6 +14,7 @@ import {
 } from 'react-native';
 import { useAuth } from '../AuthContext';
 import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
+import { supabase } from '../lib/supabase';
 
 function FollowingScreen() {
   return (
@@ -23,6 +25,18 @@ function FollowingScreen() {
 }
 
 const Tab = createMaterialTopTabNavigator();
+const TAB_BAR_HEIGHT = 48;
+
+function BlurredTabBar(props: MaterialTopTabBarProps) {
+  return (
+    <BlurView intensity={50} tint="dark" style={styles.blurredWrapper}>
+      <MaterialTopTabBar
+        {...props}
+        style={[props.style, styles.blurredBar]}
+      />
+    </BlurView>
+  );
+}
 
 export default function TopTabsNavigator() {
   const { profile, user, signOut } = useAuth() as any;
@@ -70,9 +84,11 @@ export default function TopTabsNavigator() {
       </View>
 
       <Tab.Navigator
+        tabBar={(props) => <BlurredTabBar {...props} />}
+        sceneContainerStyle={{ paddingTop: TAB_BAR_HEIGHT }}
         screenOptions={{
           tabBarStyle: {
-            backgroundColor: '#1d152b',
+            backgroundColor: 'transparent',
             marginTop: 0,
           },
           tabBarLabelStyle: {
@@ -143,5 +159,18 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     zIndex: 100,
+  },
+  blurredWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: TAB_BAR_HEIGHT,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(120,20,219,0.5)',
+    zIndex: 10,
+  },
+  blurredBar: {
+    backgroundColor: 'transparent',
   },
 });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-dev-client": "~5.1.8",
     "expo-router": "^5.0.6",
     "expo-status-bar": "~2.2.3",
+    "expo-blur": "~12.8.1",
     "process": "^0.11.10",
     "react": "19.0.0",
     "react-native": "0.79.2",


### PR DESCRIPTION
## Summary
- use `BlurView` to blur the top tab bar
- overlay the blurred bar on the posts
- include `expo-blur` in dependencies

## Testing
- `npm test` *(fails: Missing script)*