### PR TITLE
Overlay header blur and status bar

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -12,6 +12,7 @@ import {
   SafeAreaView,
   StatusBar,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuth } from '../AuthContext';
 import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
 import { supabase } from '../lib/supabase';
@@ -29,9 +30,9 @@ function FollowingScreen() {
 const Tab = createMaterialTopTabNavigator();
 const TAB_BAR_HEIGHT = 48;
 
-function BlurredTabBar(props: MaterialTopTabBarProps) {
+function BlurredTabBar({ topOffset, ...props }: MaterialTopTabBarProps & { topOffset: number }) {
   return (
-    <BlurView intensity={50} tint="dark" style={styles.blurredWrapper}>
+    <BlurView intensity={50} tint="dark" style={[styles.blurredWrapper, { top: topOffset }]}>
       <MaterialTopTabBar
         {...props}
         style={[props.style, styles.blurredBar]}
@@ -42,6 +43,8 @@ function BlurredTabBar(props: MaterialTopTabBarProps) {
 
 export default function TopTabsNavigator() {
   const { profile, user, signOut } = useAuth() as any;
+  const insets = useSafeAreaInsets();
+  const [headerHeight, setHeaderHeight] = useState(0);
   const [modalVisible, setModalVisible] = useState(false);
   const [postText, setPostText] = useState('');
   const [modalText, setModalText] = useState('');
@@ -79,8 +82,13 @@ export default function TopTabsNavigator() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <StatusBar barStyle="light-content" backgroundColor={colors.background} />
-      <BlurView intensity={50} tint="dark" style={styles.headerBlur}>
+      <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
+      <BlurView
+        intensity={50}
+        tint="dark"
+        style={[styles.headerBlur, { paddingTop: insets.top + 10 }]}
+        onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height)}
+      >
         <Text style={{ color: 'white', textAlign: 'center' }}>{welcomeText}</Text>
         <View style={{ alignItems: 'center', marginTop: 10 }}>
           <Button title="Logout" onPress={signOut} />
@@ -88,8 +96,8 @@ export default function TopTabsNavigator() {
       </BlurView>
 
       <Tab.Navigator
-        tabBar={(props) => <BlurredTabBar {...props} />}
-        sceneContainerStyle={{ paddingTop: TAB_BAR_HEIGHT }}
+        tabBar={(props) => <BlurredTabBar {...props} topOffset={headerHeight} />}
+        sceneContainerStyle={{ paddingTop: headerHeight + TAB_BAR_HEIGHT }}
         screenOptions={{
           tabBarStyle: {
             backgroundColor: 'transparent',
@@ -165,14 +173,17 @@ const styles = StyleSheet.create({
     zIndex: 100,
   },
   headerBlur: {
-    paddingTop: 10,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
     paddingBottom: 10,
     backgroundColor: 'rgba(29,21,43,0.6)',
+    zIndex: 20,
   },
 
   blurredWrapper: {
     position: 'absolute',
-    top: 0,
     left: 0,
     right: 0,
     height: TAB_BAR_HEIGHT,


### PR DESCRIPTION
## Summary
- blur the status bar and header areas
- keep blurred tab bar
- allow posts to scroll beneath the blurred overlays
- measure header height and use it to position tab bar, closing the gap

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find expo tsconfig base)*