### PR TITLE
Fix tab offset to include header padding

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -51,8 +51,8 @@ export default function TopTabsNavigator() {
   const insets = useSafeAreaInsets();
   const HEADER_CONTENT_HEIGHT = 70;
   const headerHeight = insets.top + HEADER_CONTENT_HEIGHT;
-  // Align the tab bar with the bottom of the header
-  const tabTopOffset = headerHeight - TAB_BAR_HEIGHT;
+  // Move the tab bar 10% higher relative to the header's bottom padding
+  const tabTopOffset = (headerHeight + HEADER_BOTTOM_PADDING) * 0.9;
 
 
   const [modalVisible, setModalVisible] = useState(false);


### PR DESCRIPTION
## Summary
- account for bottom padding when positioning the top tab bar
- raise top tab bar by 10 percent

## Testing
- `npm test` *(fails: Missing script)*