### PR TITLE
Fix tab offset to include header padding

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -34,6 +34,7 @@ function FollowingScreen() {
 const Tab = createMaterialTopTabNavigator();
 const TAB_BAR_HEIGHT = 48;
 const HEADER_BOTTOM_PADDING = 10;
+const BLUR_BACKGROUND_COLOR = 'rgba(29,21,43,0.6)';
 
 function BlurredTabBar({ topOffset, ...props }: MaterialTopTabBarProps & { topOffset: number }) {
   return (
@@ -51,8 +52,8 @@ export default function TopTabsNavigator() {
   const insets = useSafeAreaInsets();
   const HEADER_CONTENT_HEIGHT = 70;
   const headerHeight = insets.top + HEADER_CONTENT_HEIGHT;
-  // Align the tab bar with the bottom of the header
-  const tabTopOffset = headerHeight - TAB_BAR_HEIGHT;
+  // Align the tab bar with the bottom of the header including padding
+  const tabTopOffset = headerHeight + HEADER_BOTTOM_PADDING;
 
 
   const [modalVisible, setModalVisible] = useState(false);
@@ -184,9 +185,8 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    paddingBottom: 10,
-
-    backgroundColor: 'rgba(29,21,43,0.6)',
+    paddingBottom: HEADER_BOTTOM_PADDING,
+    backgroundColor: BLUR_BACKGROUND_COLOR,
     zIndex: 20,
   },
 
@@ -195,9 +195,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     height: TAB_BAR_HEIGHT,
-    overflow: 'hidden',
-    backgroundColor: 'rgba(29,21,43,0.6)',
-
+    backgroundColor: BLUR_BACKGROUND_COLOR,
     zIndex: 10,
   },
   blurredBar: {


### PR DESCRIPTION
## Summary
- account for bottom padding when positioning the top tab bar
- align blurred styles so the header and tab bar blend

## Testing
- `npm test` *(fails: Missing script)*