### PR TITLE
Add floating reply input on post detail

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -51,6 +51,7 @@ function HeaderTabBar(
       tint="dark"
       style={[styles.headerBlur, { paddingTop: insetsTop + 10 }]}
     >
+      <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
       <Text style={{ color: 'white', textAlign: 'center' }}>{welcomeText}</Text>
       <View style={{ alignItems: 'center', marginTop: 10 }}>
         <Button title="Logout" onPress={signOut} />
@@ -110,7 +111,6 @@ export default function TopTabsNavigator() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
-      <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
       <Tab.Navigator
         tabBar={(props) => (
           <HeaderTabBar

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -165,16 +165,8 @@ export default function PostDetailScreen() {
         <Text style={styles.postContent}>{post.content}</Text>
       </View>
 
-      <TextInput
-        placeholder="Write a reply"
-        value={replyText}
-        onChangeText={setReplyText}
-        style={styles.input}
-        multiline
-      />
-      <Button title="Post" onPress={handleReply} />
-
       <FlatList
+        contentContainerStyle={{ paddingBottom: 100 }}
         data={replies}
         keyExtractor={item => item.id}
         renderItem={({ item }) => {
@@ -191,6 +183,17 @@ export default function PostDetailScreen() {
           );
         }}
       />
+
+      <View style={styles.inputContainer}>
+        <TextInput
+          placeholder="Write a reply"
+          value={replyText}
+          onChangeText={setReplyText}
+          style={styles.input}
+          multiline
+        />
+        <Button title="Post" onPress={handleReply} />
+      </View>
     </View>
   );
 }
@@ -226,5 +229,13 @@ const styles = StyleSheet.create({
   backButton: {
     alignSelf: 'flex-start',
     marginBottom: 10,
+  },
+  inputContainer: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 0,
+    backgroundColor: colors.background,
+    paddingBottom: 16,
   },
 });


### PR DESCRIPTION
## Summary
- keep status bar blur unchanged
- float the reply field and button at the bottom of the PostDetailScreen
- add bottom padding to the replies list so content isn't hidden under the overlay

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find declarations)*