### PR TITLE
Add highlight for parent post in detail feed

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -198,6 +198,13 @@ export default function PostDetailScreen() {
       </View>
 
       <FlatList
+        ListHeaderComponent={() => (
+          <View style={[styles.post, styles.highlightPost]}>
+            <Text style={styles.username}>@{displayName}</Text>
+            <Text style={styles.postContent}>{post.content}</Text>
+            <Text style={styles.timestamp}>{timeAgo(post.created_at)}</Text>
+          </View>
+        )}
         contentContainerStyle={{ paddingBottom: 100 }}
         data={replies}
         keyExtractor={item => item.id}
@@ -242,6 +249,9 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     padding: 10,
     marginBottom: 10,
+  },
+  highlightPost: {
+    backgroundColor: '#c8102e',
   },
   reply: {
     backgroundColor: '#ffffff10',


### PR DESCRIPTION
## Summary
- show the parent post again inside `PostDetailScreen`'s scrollable feed
- style that copy with highlight color `#c8102e`

## Testing
- `npm test` *(fails: Missing script)*