### PR TITLE
Expand drawer width to 80% of screen

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -16,6 +16,7 @@ import {
   StatusBar,
   Animated,
   TouchableWithoutFeedback,
+  Dimensions,
 } from 'react-native';
 import {
   SafeAreaView,
@@ -40,6 +41,8 @@ const Tab = createMaterialTopTabNavigator();
 const TAB_BAR_HEIGHT = 48;
 const HEADER_BOTTOM_PADDING = 0;
 const BLUR_BACKGROUND_COLOR = 'rgba(29,21,43,0.6)';
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const DRAWER_WIDTH = SCREEN_WIDTH * 0.8;
 
 
 function HeaderTabBar(
@@ -136,9 +139,15 @@ export default function TopTabsNavigator() {
     }).start(() => setDrawerOpen(false));
   };
 
-  const translateX = drawerAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 200] });
+  const translateX = drawerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, DRAWER_WIDTH],
+  });
   const overlayOpacity = drawerAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 0.3] });
-  const drawerTranslate = drawerAnim.interpolate({ inputRange: [0, 1], outputRange: [-200, 0] });
+  const drawerTranslate = drawerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-DRAWER_WIDTH, 0],
+  });
 
   return (
     <SafeAreaView
@@ -263,7 +272,7 @@ const styles = StyleSheet.create({
     left: 0,
     top: 0,
     bottom: 0,
-    width: 200,
+    width: DRAWER_WIDTH,
     backgroundColor: '#1d152b',
     paddingTop: 100,
     paddingHorizontal: 20,


### PR DESCRIPTION
## Summary
- extend drawer to occupy 80% of the screen width
- shift main tab navigator accordingly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*