### PR TITLE
Fix navigation import duplication

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -4,6 +4,7 @@ import AuthPage from './AuthPage';
 import TopTabsNavigator from './app/TopTabsNavigator';
 import PostDetailScreen from './app/screens/PostDetailScreen';
 import ReplyDetailScreen from './app/screens/ReplyDetailScreen';
+import ProfileScreen from './app/screens/ProfileScreen';
 import { useAuth } from './AuthContext';
 
 const Stack = createNativeStackNavigator();
@@ -20,6 +21,7 @@ export default function Navigator() {
           <Stack.Screen name="Tabs" component={TopTabsNavigator} />
           <Stack.Screen name="PostDetail" component={PostDetailScreen} />
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
         </>
       ) : (
         <Stack.Screen name="Auth" component={AuthPage} />

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -16,11 +16,13 @@ import {
   StatusBar,
   Animated,
   TouchableWithoutFeedback,
+  Dimensions,
 } from 'react-native';
 import {
   SafeAreaView,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
 
 import { useAuth } from '../AuthContext';
 import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
@@ -40,6 +42,8 @@ const Tab = createMaterialTopTabNavigator();
 const TAB_BAR_HEIGHT = 48;
 const HEADER_BOTTOM_PADDING = 0;
 const BLUR_BACKGROUND_COLOR = 'rgba(29,21,43,0.6)';
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const DRAWER_WIDTH = SCREEN_WIDTH * 0.8;
 
 
 function HeaderTabBar(
@@ -74,6 +78,7 @@ function HeaderTabBar(
 export default function TopTabsNavigator() {
   const { profile, user, signOut } = useAuth() as any;
   const insets = useSafeAreaInsets();
+  const navigation = useNavigation<any>();
   const HEADER_CONTENT_HEIGHT = 70;
   const headerHeight = insets.top + HEADER_CONTENT_HEIGHT;
   const HEADER_TOTAL_HEIGHT =
@@ -136,9 +141,15 @@ export default function TopTabsNavigator() {
     }).start(() => setDrawerOpen(false));
   };
 
-  const translateX = drawerAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 200] });
+  const translateX = drawerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, DRAWER_WIDTH],
+  });
   const overlayOpacity = drawerAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 0.3] });
-  const drawerTranslate = drawerAnim.interpolate({ inputRange: [0, 1], outputRange: [-200, 0] });
+  const drawerTranslate = drawerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-DRAWER_WIDTH, 0],
+  });
 
   return (
     <SafeAreaView
@@ -206,7 +217,7 @@ export default function TopTabsNavigator() {
       )}
 
       <Animated.View style={[styles.drawer, { transform: [{ translateX: drawerTranslate }] }]}>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => { closeDrawer(); navigation.navigate('Profile'); }}>
           <Text style={styles.menuItem}>Profile</Text>
         </TouchableOpacity>
       </Animated.View>
@@ -263,7 +274,7 @@ const styles = StyleSheet.create({
     left: 0,
     top: 0,
     bottom: 0,
-    width: 200,
+    width: DRAWER_WIDTH,
     backgroundColor: '#1d152b',
     paddingTop: 100,
     paddingHorizontal: 20,

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../../AuthContext';
+import { colors } from '../styles/colors';
+
+export default function ProfileScreen() {
+  const { profile } = useAuth() as any;
+  const username = profile?.username || 'Unknown';
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.username}>@{username}</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  username: {
+    color: 'white',
+    fontSize: 18,
+  },
+});


### PR DESCRIPTION
## Summary
- add missing ProfileScreen
- register ProfileScreen in the stack navigator
- navigate to Profile from drawer and import navigation only once

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*