### PR TITLE
Add profile picture upload

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet, Image } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
 
 import { useAuth } from '../../AuthContext';
@@ -8,6 +10,39 @@ import { colors } from '../styles/colors';
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
   const { profile } = useAuth() as any;
+  const [imageUri, setImageUri] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!profile) return;
+      const uri = await AsyncStorage.getItem(`profile_pic_${profile.id}`);
+      if (uri) setImageUri(uri);
+    };
+    load();
+  }, [profile]);
+
+  const pickImage = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      alert('Permission to access photos is required');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.5,
+    });
+
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      const uri = result.assets[0].uri;
+      setImageUri(uri);
+      if (profile) {
+        await AsyncStorage.setItem(`profile_pic_${profile.id}`, uri);
+      }
+    }
+  };
 
   if (!profile) return null;
 
@@ -16,6 +51,16 @@ export default function ProfileScreen() {
       <View style={styles.backButton}>
         <Button title="Back" onPress={() => navigation.goBack()} />
       </View>
+      <View style={styles.headerRow}>
+        <Image
+          source={
+            imageUri ? { uri: imageUri } : require('../../assets/logo.png')
+          }
+          style={styles.avatar}
+        />
+        <Button title="Upload Profile Picture" onPress={pickImage} />
+      </View>
+
       <Text style={styles.username}>@{profile.username}</Text>
       {profile.display_name && (
         <Text style={styles.name}>{profile.display_name}</Text>
@@ -34,6 +79,17 @@ const styles = StyleSheet.create({
   backButton: {
     alignSelf: 'flex-start',
     marginBottom: 20,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 20,
+  },
+  avatar: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
   },
   username: {
     color: 'white',

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "expo-dev-client": "~5.1.8",
     "expo-router": "^5.0.6",
     "expo-status-bar": "~2.2.3",
-    "expo-blur": "~12.4.0"
-,
+    "expo-image-picker": "~15.2.1",
+    "expo-blur": "~12.4.0",
     "process": "^0.11.10",
     "react": "19.0.0",
     "react-native": "0.79.2",


### PR DESCRIPTION
## Summary
- allow uploading and saving a profile picture on Profile screen
- style profile layout with circular avatar
- add `expo-image-picker` dependency
- request permission before letting users choose an image

## Testing
- `npm test` *(fails: Missing script)*