### PR TITLE
Add permissions before picking profile picture

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -22,6 +22,11 @@ export default function ProfileScreen() {
   }, [profile]);
 
   const pickImage = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      alert('Permission to access images is required!');
+      return;
+    }
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,


### PR DESCRIPTION
## Summary
- request media library permissions before launching the picker

## Testing
- `npm test` *(fails: Missing script)*