### PR TITLE
Add permission check for profile photo upload

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -22,6 +22,14 @@ export default function ProfileScreen() {
   }, [profile]);
 
   const pickImage = async () => {
+    let permission = await ImagePicker.getMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    }
+    if (!permission.granted) {
+      alert('Permission to access images is required!');
+      return;
+    }
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,


### PR DESCRIPTION
## Summary
- ensure the app checks current media permission before asking the user

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'expo' etc.)*