### PR TITLE
Add media permission check before picker

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -22,6 +22,15 @@ export default function ProfileScreen() {
   }, [profile]);
 
   const pickImage = async () => {
+    let { granted } = await ImagePicker.getMediaLibraryPermissionsAsync();
+    if (!granted) {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      granted = permission.granted;
+    }
+    if (!granted) {
+      alert('Permission to access images is required!');
+      return;
+    }
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,


### PR DESCRIPTION
## Summary
- ask for existing permissions and request them if needed before launching image picker

## Testing
- `npm test` *(fails: Missing script)*