### PR TITLE
Persist reply counts

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -24,6 +24,7 @@ type Post = {
   username?: string;
   user_id: string;
   created_at: string;
+  reply_count?: number;
   profiles?: {
     username: string | null;
     display_name: string | null;
@@ -55,6 +56,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { user, profile, profileImageUri } = useAuth() as any;
     const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
+  const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
@@ -73,6 +75,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setReplyCounts(prev => {
+      const { [id]: _removed, ...rest } = prev;
+      return rest;
+    });
     await supabase.from('posts').delete().eq('id', id);
   };
 
@@ -82,12 +88,14 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const fetchPosts = async () => {
     const { data, error } = await supabase
       .from('posts')
-      .select('id, content, user_id, created_at, profiles(username, display_name)')
+      .select('id, content, user_id, created_at, reply_count, profiles(username, display_name)')
       .order('created_at', { ascending: false });
 
     if (!error && data) {
       setPosts(data as Post[]);
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      const entries = (data as any[]).map(p => [p.id, p.reply_count ?? 0]);
+      setReplyCounts(Object.fromEntries(entries));
     }
   };
 
@@ -102,6 +110,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       username: profile.display_name || profile.username,
       user_id: user.id,
       created_at: new Date().toISOString(),
+      reply_count: 0,
       profiles: {
         username: profile.username,
         display_name: profile.display_name,
@@ -114,6 +123,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setReplyCounts(prev => ({ ...prev, [newPost.id]: 0 }));
     if (!hideInput) {
       setPostText('');
     }
@@ -150,6 +160,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
           return updated;
         });
+        setReplyCounts(prev => {
+          const { [newPost.id]: tempCount, ...rest } = prev;
+          return { ...rest, [data.id]: tempCount };
+        });
       }
 
       // Refresh from the server in the background to stay in sync
@@ -180,7 +194,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
       if (stored) {
         try {
-          setPosts(JSON.parse(stored));
+          const cached = JSON.parse(stored);
+          setPosts(cached);
+          const entries = cached.map((p: any) => [p.id, p.reply_count ?? 0]);
+          setReplyCounts(Object.fromEntries(entries));
         } catch (e) {
           console.error('Failed to parse cached posts', e);
         }
@@ -244,6 +261,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                     <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
+                <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
               </View>
             </TouchableOpacity>
           );
@@ -289,6 +307,7 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  replyCount: { position: 'absolute', bottom: 6, left: 10, fontSize: 10, color: 'gray' },
 });
 
 export default HomeScreen;

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -40,6 +40,7 @@ interface Reply {
   user_id: string;
   content: string;
   created_at: string;
+  reply_count?: number;
   username?: string;
   profiles?: {
     username: string | null;
@@ -52,6 +53,7 @@ interface Post {
   content: string;
   user_id: string;
   created_at: string;
+  reply_count?: number;
   username?: string;
   profiles?: {
     username: string | null;
@@ -72,6 +74,8 @@ export default function ReplyDetailScreen() {
 
   const [replyText, setReplyText] = useState('');
   const [replies, setReplies] = useState<Reply[]>([]);
+  const [allReplies, setAllReplies] = useState<Reply[]>([]);
+  const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
   const [keyboardOffset, setKeyboardOffset] = useState(0);
 
   const confirmDeletePost = (id: string) => {
@@ -108,23 +112,64 @@ export default function ReplyDetailScreen() {
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setAllReplies(prev => {
+      const descendants = new Set<string>();
+      const gather = (parentId: string) => {
+        prev.forEach(r => {
+          if (r.parent_id === parentId) {
+            descendants.add(r.id);
+            gather(r.id);
+          }
+        });
+      };
+      gather(id);
+      return prev.filter(r => r.id !== id && !descendants.has(r.id));
+    });
+    setReplyCounts(prev => {
+      const descendants = new Set<string>();
+      const gather = (parentId: string) => {
+        allReplies.forEach(r => {
+          if (r.parent_id === parentId) {
+            descendants.add(r.id);
+            gather(r.id);
+          }
+        });
+      };
+      gather(id);
+      let removed = descendants.size + 1;
+      const { [id]: _omit, ...rest } = prev;
+      descendants.forEach(d => delete rest[d]);
+      return { ...rest, [parent.id]: (prev[parent.id] || 0) - removed };
+    });
 
     await supabase.from('replies').delete().eq('id', id);
   };
 
+
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      .select('id, post_id, parent_id, user_id, content, created_at, username')
-      .eq('parent_id', parent.id)
+      .select('id, post_id, parent_id, user_id, content, created_at, reply_count, username')
+      .eq('post_id', parent.post_id)
       .order('created_at', { ascending: false });
     if (!error && data) {
+      const all = data as Reply[];
+      setAllReplies(all);
+      const children = all.filter(r => r.parent_id === parent.id);
       setReplies(prev => {
         const temp = prev.filter(r => r.id.startsWith('temp-'));
-        const merged = [...temp, ...(data as Reply[])];
+        const merged = [...temp, ...children];
         AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
         return merged;
       });
+      const { data: postData } = await supabase
+        .from('posts')
+        .select('reply_count')
+        .eq('id', parent.post_id)
+        .single();
+      const entries = all.map(r => [r.id, r.reply_count ?? 0]);
+      if (postData) entries.push([parent.post_id, postData.reply_count ?? all.length]);
+      setReplyCounts(Object.fromEntries(entries));
     }
   };
 
@@ -133,7 +178,11 @@ export default function ReplyDetailScreen() {
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
       if (stored) {
         try {
-          setReplies(JSON.parse(stored));
+          const cached = JSON.parse(stored);
+          setReplies(cached);
+          setAllReplies(cached);
+          const entries = cached.map((r: any) => [r.id, r.reply_count ?? 0]);
+          setReplyCounts(prev => ({ ...prev, ...Object.fromEntries(entries) }));
         } catch (e) {
           console.error('Failed to parse cached replies', e);
         }
@@ -168,6 +217,7 @@ export default function ReplyDetailScreen() {
       user_id: user.id,
       content: replyText,
       created_at: new Date().toISOString(),
+      reply_count: 0,
       username: profile.display_name || profile.username,
       profiles: { username: profile.username, display_name: profile.display_name },
     };
@@ -177,6 +227,12 @@ export default function ReplyDetailScreen() {
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setAllReplies(prev => [...prev, newReply]);
+    setReplyCounts(prev => ({
+      ...prev,
+      [parent.id]: (prev[parent.id] || 0) + 1,
+      [newReply.id]: 0,
+    }));
     setReplyText('');
 
     let { data, error } = await supabase
@@ -201,6 +257,14 @@ export default function ReplyDetailScreen() {
         setReplies(prev =>
           prev.map(r => (r.id === newReply.id ? { ...r, id: data.id, created_at: data.created_at } : r)),
         );
+        setAllReplies(prev =>
+          prev.map(r => (r.id === newReply.id ? { ...r, id: data.id, created_at: data.created_at } : r)),
+        );
+        setReplyCounts(prev => {
+          const temp = prev[newReply.id] ?? 0;
+          const { [newReply.id]: _omit, ...rest } = prev;
+          return { ...rest, [data.id]: temp, [parent.id]: prev[parent.id] || 0 };
+        });
       }
       fetchReplies();
     }
@@ -256,6 +320,7 @@ export default function ReplyDetailScreen() {
                     <Text style={styles.timestamp}>{timeAgo(originalPost.created_at)}</Text>
                   </View>
                 </View>
+                <Text style={styles.replyCount}>{replyCounts[originalPost.id] || 0}</Text>
               </View>
             )}
               {ancestors.map(a => {
@@ -287,12 +352,13 @@ export default function ReplyDetailScreen() {
                         {ancestorName} @{ancestorUserName}
                       </Text>
                       <Text style={styles.postContent}>{a.content}</Text>
-                      <Text style={styles.timestamp}>{timeAgo(a.created_at)}</Text>
-                    </View>
+                    <Text style={styles.timestamp}>{timeAgo(a.created_at)}</Text>
                   </View>
                 </View>
-              );
-            })}
+                <Text style={styles.replyCount}>{replyCounts[a.id] || 0}</Text>
+              </View>
+            );
+          })}
 
             <View style={styles.post}>
               {user?.id === parent.user_id && (
@@ -317,6 +383,7 @@ export default function ReplyDetailScreen() {
                   <Text style={styles.timestamp}>{timeAgo(parent.created_at)}</Text>
                 </View>
               </View>
+            <Text style={styles.replyCount}>{replyCounts[parent.id] || 0}</Text>
             </View>
           </>
         )}
@@ -362,6 +429,7 @@ export default function ReplyDetailScreen() {
                     <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
+                <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
               </View>
             </TouchableOpacity>
           );
@@ -430,6 +498,7 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  replyCount: { position: 'absolute', bottom: 6, left: 10, fontSize: 10, color: 'gray' },
   input: {
     backgroundColor: 'white',
     padding: 10,
@@ -445,15 +514,6 @@ const styles = StyleSheet.create({
     right: 6,
     top: 6,
     padding: 4,
-  },
-  threadLine: {
-    position: 'absolute',
-    left: 26,
-    top: 42,
-    bottom: -20,
-    width: 2,
-    backgroundColor: '#6f6b8e',
-
   },
   inputContainer: {
     position: 'absolute',

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -23,7 +23,8 @@ create table if not exists public.posts (
     user_id uuid not null references public.profiles(id) on delete cascade,
     username text not null,
     content text not null,
-    created_at timestamptz not null default now()
+    created_at timestamptz not null default now(),
+    reply_count integer not null default 0
 );
 
 -- Enable Row Level Security and allow cross-user access
@@ -48,13 +49,53 @@ create table if not exists public.replies (
     user_id uuid not null references public.profiles(id) on delete cascade,
     username text not null,
     content text not null,
-    created_at timestamptz not null default now()
+    created_at timestamptz not null default now(),
+    reply_count integer not null default 0
 );
 alter table public.replies enable row level security;
 create policy "Users can insert replies" on public.replies
   for insert with check (auth.uid() = user_id);
 create policy "Anyone can read replies" on public.replies
   for select using (true);
+
+-- Maintain nested reply counts for posts and replies
+create or replace function public.increment_reply_counts() returns trigger as $$
+declare
+  current uuid;
+begin
+  update public.posts set reply_count = reply_count + 1 where id = NEW.post_id;
+  current := NEW.parent_id;
+  while current is not null loop
+    update public.replies set reply_count = reply_count + 1
+      where id = current
+      returning parent_id into current;
+  end loop;
+  return NEW;
+end;
+$$ language plpgsql;
+
+create or replace function public.decrement_reply_counts() returns trigger as $$
+declare
+  current uuid;
+begin
+  update public.posts set reply_count = reply_count - 1 where id = OLD.post_id;
+  current := OLD.parent_id;
+  while current is not null loop
+    update public.replies set reply_count = reply_count - 1
+      where id = current
+      returning parent_id into current;
+  end loop;
+  return OLD;
+end;
+$$ language plpgsql;
+
+create trigger replies_insert_reply_count
+after insert on public.replies
+for each row execute procedure public.increment_reply_counts();
+
+create trigger replies_delete_reply_count
+after delete on public.replies
+for each row execute procedure public.decrement_reply_counts();
 
 -- Example: insert a profile row so posting succeeds for a user
 -- Replace the UUID and username with your values


### PR DESCRIPTION
## Summary
- store reply counts in `posts` and `replies` tables
- add triggers to increment and decrement counts
- fetch `reply_count` values from Supabase on all screens
- display saved counts on all post and reply cards

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*