### PR TITLE
Add nested reply counts

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
+import React, { useEffect, useState, forwardRef, useImperativeHandle, useCallback } from 'react';
 import {
   View,
   TextInput,
@@ -10,7 +10,7 @@ import {
   TouchableOpacity,
   Image,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
@@ -55,6 +55,22 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { user, profile, profileImageUri } = useAuth() as any;
     const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
+  const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
+
+  const fetchReplyCount = async (postId: string) => {
+    const { count } = await supabase
+      .from('replies')
+      .select('id', { count: 'exact', head: true })
+      .eq('post_id', postId);
+    return count || 0;
+  };
+
+  const fetchCountsForPosts = async (postList: Post[]) => {
+    const entries = await Promise.all(
+      postList.map(async p => [p.id, await fetchReplyCount(p.id)] as [string, number]),
+    );
+    setReplyCounts(Object.fromEntries(entries));
+  };
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
@@ -73,6 +89,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setReplyCounts(prev => {
+      const { [id]: _removed, ...rest } = prev;
+      return rest;
+    });
     await supabase.from('posts').delete().eq('id', id);
   };
 
@@ -88,6 +108,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     if (!error && data) {
       setPosts(data as Post[]);
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      fetchCountsForPosts(data as Post[]);
     }
   };
 
@@ -114,6 +135,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setReplyCounts(prev => ({ ...prev, [newPost.id]: 0 }));
     if (!hideInput) {
       setPostText('');
     }
@@ -150,6 +172,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
           return updated;
         });
+        setReplyCounts(prev => {
+          const { [newPost.id]: tempCount, ...rest } = prev;
+          return { ...rest, [data.id]: tempCount };
+        });
       }
 
       // Refresh from the server in the background to stay in sync
@@ -180,7 +206,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
       if (stored) {
         try {
-          setPosts(JSON.parse(stored));
+          const cached = JSON.parse(stored);
+          setPosts(cached);
+          fetchCountsForPosts(cached);
         } catch (e) {
           console.error('Failed to parse cached posts', e);
         }
@@ -191,6 +219,12 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
     loadCached();
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchPosts();
+    }, []),
+  );
 
   return (
     
@@ -244,6 +278,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                     <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
+                <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
               </View>
             </TouchableOpacity>
           );
@@ -289,6 +324,7 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  replyCount: { position: 'absolute', bottom: 6, left: 10, fontSize: 10, color: 'gray' },
 });
 
 export default HomeScreen;

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -69,6 +69,8 @@ export default function PostDetailScreen() {
 
   const [replyText, setReplyText] = useState('');
   const [replies, setReplies] = useState<Reply[]>([]);
+  const [allReplies, setAllReplies] = useState<Reply[]>([]);
+  const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
   const [keyboardOffset, setKeyboardOffset] = useState(0);
 
   const confirmDeletePost = (id: string) => {
@@ -104,6 +106,35 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setAllReplies(prev => {
+      const descendants = new Set<string>();
+      const gather = (parentId: string) => {
+        prev.forEach(r => {
+          if (r.parent_id === parentId) {
+            descendants.add(r.id);
+            gather(r.id);
+          }
+        });
+      };
+      gather(id);
+      return prev.filter(r => r.id !== id && !descendants.has(r.id));
+    });
+    setReplyCounts(prev => {
+      const descendants = new Set<string>();
+      const gather = (parentId: string) => {
+        allReplies.forEach(r => {
+          if (r.parent_id === parentId) {
+            descendants.add(r.id);
+            gather(r.id);
+          }
+        });
+      };
+      gather(id);
+      let removed = descendants.size + 1;
+      const { [id]: _omit, ...rest } = prev;
+      descendants.forEach(d => delete rest[d]);
+      return { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+    });
     await supabase.from('replies').delete().eq('id', id);
   };
 
@@ -122,25 +153,46 @@ export default function PostDetailScreen() {
     };
   }, []);
 
+  const computeCounts = (replyList: Reply[]) => {
+    const childrenMap: { [key: string]: Reply[] } = {};
+    replyList.forEach(r => {
+      if (r.parent_id) {
+        if (!childrenMap[r.parent_id]) childrenMap[r.parent_id] = [];
+        childrenMap[r.parent_id].push(r);
+      }
+    });
+    const counts: { [key: string]: number } = {};
+    const countRec = (id: string): number => {
+      const children = childrenMap[id] || [];
+      let total = children.length;
+      for (const c of children) total += countRec(c.id);
+      counts[id] = total;
+      return total;
+    };
+    replyList.forEach(r => {
+      if (!counts[r.id]) countRec(r.id);
+    });
+    counts[post.id] = replyList.length;
+    return counts;
+  };
+
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      // fetch only reply fields to avoid missing relationship errors
       .select('id, post_id, parent_id, user_id, content, created_at, username')
       .eq('post_id', post.id)
-      .is('parent_id', null)
       .order('created_at', { ascending: false });
     if (!error && data) {
+      const all = data as Reply[];
+      setAllReplies(all);
+      const topLevel = all.filter(r => r.parent_id === null);
       setReplies(prev => {
-        // Keep any replies that haven't been synced yet (ids starting with "temp-")
         const tempReplies = prev.filter(r => r.id.startsWith('temp-'));
-        const merged = [...tempReplies, ...(data as Reply[])];
-
-
+        const merged = [...tempReplies, ...topLevel];
         AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
         return merged;
       });
-
+      setReplyCounts(computeCounts(all));
     }
   };
 
@@ -181,6 +233,12 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
+    setAllReplies(prev => [...prev, newReply]);
+    setReplyCounts(prev => ({
+      ...prev,
+      [post.id]: (prev[post.id] || 0) + 1,
+      [newReply.id]: 0,
+    }));
     setReplyText('');
 
     let { data, error } = await supabase
@@ -209,6 +267,14 @@ export default function PostDetailScreen() {
             r.id === newReply.id ? { ...r, id: data.id, created_at: data.created_at } : r,
           ),
         );
+        setAllReplies(prev =>
+          prev.map(r => (r.id === newReply.id ? { ...r, id: data.id, created_at: data.created_at } : r)),
+        );
+        setReplyCounts(prev => {
+          const temp = prev[newReply.id] ?? 0;
+          const { [newReply.id]: _omit, ...rest } = prev;
+          return { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+        });
       }
 
       // Whether or not data was returned, refresh from the server so the reply persists
@@ -255,6 +321,7 @@ export default function PostDetailScreen() {
                 <Text style={styles.timestamp}>{timeAgo(post.created_at)}</Text>
               </View>
             </View>
+            <Text style={styles.replyCount}>{replyCounts[post.id] || 0}</Text>
           </View>
         )}
         contentContainerStyle={{ paddingBottom: 100 }}
@@ -297,9 +364,10 @@ export default function PostDetailScreen() {
                       <Text style={styles.postContent}>{item.content}</Text>
                       <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                     </View>
+                  </View>
+                  <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
                 </View>
-              </View>
-            </TouchableOpacity>
+              </TouchableOpacity>
           );
         }}
       />
@@ -357,6 +425,7 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  replyCount: { position: 'absolute', bottom: 6, left: 10, fontSize: 10, color: 'gray' },
   input: {
     backgroundColor: 'white',
     padding: 10,


### PR DESCRIPTION
## Summary
- compute reply counts for each post and reply
- display counts on post cards and all reply cards
- refresh feed counts when returning to the home screen

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*