### PR TITLE
Enable persistent reply counts in feed

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 function timeAgo(dateString: string): string {
   const diff = Date.now() - new Date(dateString).getTime();
@@ -137,7 +138,9 @@ export default function PostDetailScreen() {
       let removed = descendants.size + 1;
       const { [id]: _omit, ...rest } = prev;
       descendants.forEach(d => delete rest[d]);
-      return { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+      const counts = { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
     });
     await supabase.from('replies').delete().eq('id', id);
     fetchReplies();
@@ -186,7 +189,9 @@ export default function PostDetailScreen() {
       const entries = all.map(r => [r.id, r.reply_count ?? 0]);
       if (postData) entries.push([post.id, postData.reply_count ?? all.length]);
       else entries.push([post.id, post.reply_count ?? all.length]);
-      setReplyCounts(Object.fromEntries(entries));
+      const counts = Object.fromEntries(entries);
+      setReplyCounts(counts);
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
 
     }
   };
@@ -201,10 +206,18 @@ export default function PostDetailScreen() {
           setAllReplies(cached);
           const entries = cached.map((r: any) => [r.id, r.reply_count ?? 0]);
           entries.push([post.id, post.reply_count ?? cached.length]);
-          setReplyCounts(Object.fromEntries(entries));
-
+          const counts = Object.fromEntries(entries);
+          setReplyCounts(counts);
         } catch (e) {
           console.error('Failed to parse cached replies', e);
+        }
+      }
+      const countStored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+      if (countStored) {
+        try {
+          setReplyCounts(prev => ({ ...prev, ...JSON.parse(countStored) }));
+        } catch (e) {
+          console.error('Failed to parse cached counts', e);
         }
       }
 
@@ -236,11 +249,11 @@ export default function PostDetailScreen() {
       return updated;
     });
     setAllReplies(prev => [...prev, newReply]);
-    setReplyCounts(prev => ({
-      ...prev,
-      [post.id]: (prev[post.id] || 0) + 1,
-      [newReply.id]: 0,
-    }));
+    setReplyCounts(prev => {
+      const counts = { ...prev, [post.id]: (prev[post.id] || 0) + 1, [newReply.id]: 0 };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -284,7 +297,9 @@ export default function PostDetailScreen() {
         setReplyCounts(prev => {
           const temp = prev[newReply.id] ?? 0;
           const { [newReply.id]: _omit, ...rest } = prev;
-          return { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+          const counts = { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
         });
 
       }

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 
 const CHILD_PREFIX = 'cached_child_replies_';
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 function timeAgo(dateString: string): string {
   const diff = Date.now() - new Date(dateString).getTime();
@@ -141,7 +142,9 @@ export default function ReplyDetailScreen() {
       let removed = descendants.size + 1;
       const { [id]: _omit, ...rest } = prev;
       descendants.forEach(d => delete rest[d]);
-      return { ...rest, [parent.id]: (prev[parent.id] || 0) - removed };
+      const counts = { ...rest, [parent.id]: (prev[parent.id] || 0) - removed };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
     });
 
     await supabase.from('replies').delete().eq('id', id);
@@ -174,7 +177,9 @@ export default function ReplyDetailScreen() {
         .single();
       const entries = all.map(r => [r.id, r.reply_count ?? 0]);
       if (postData) entries.push([parent.post_id, postData.reply_count ?? all.length]);
-      setReplyCounts(Object.fromEntries(entries));
+      const counts = Object.fromEntries(entries);
+      setReplyCounts(counts);
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
 
     }
   };
@@ -189,9 +194,16 @@ export default function ReplyDetailScreen() {
           setAllReplies(cached);
           const entries = cached.map((r: any) => [r.id, r.reply_count ?? 0]);
           setReplyCounts(prev => ({ ...prev, ...Object.fromEntries(entries) }));
-
         } catch (e) {
           console.error('Failed to parse cached replies', e);
+        }
+      }
+      const countStored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+      if (countStored) {
+        try {
+          setReplyCounts(prev => ({ ...prev, ...JSON.parse(countStored) }));
+        } catch (e) {
+          console.error('Failed to parse cached counts', e);
         }
       }
       fetchReplies();
@@ -236,11 +248,11 @@ export default function ReplyDetailScreen() {
       return updated;
     });
     setAllReplies(prev => [...prev, newReply]);
-    setReplyCounts(prev => ({
-      ...prev,
-      [parent.id]: (prev[parent.id] || 0) + 1,
-      [newReply.id]: 0,
-    }));
+    setReplyCounts(prev => {
+      const counts = { ...prev, [parent.id]: (prev[parent.id] || 0) + 1, [newReply.id]: 0 };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -286,7 +298,9 @@ export default function ReplyDetailScreen() {
         setReplyCounts(prev => {
           const temp = prev[newReply.id] ?? 0;
           const { [newReply.id]: _omit, ...rest } = prev;
-          return { ...rest, [data.id]: temp, [parent.id]: prev[parent.id] || 0 };
+          const counts = { ...rest, [data.id]: temp, [parent.id]: prev[parent.id] || 0 };
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
         });
 
       }


### PR DESCRIPTION
## Summary
- persist reply counts to `AsyncStorage`
- restore counts when fetching posts or updating posts
- sync detail screen changes with cached counts

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*