### PR TITLE
Enable persistent reply counts in feed

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 function timeAgo(dateString: string): string {
   const diff = Date.now() - new Date(dateString).getTime();
@@ -137,7 +138,9 @@ export default function PostDetailScreen() {
       let removed = descendants.size + 1;
       const { [id]: _omit, ...rest } = prev;
       descendants.forEach(d => delete rest[d]);
-      return { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+      const counts = { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
     });
     await supabase.from('replies').delete().eq('id', id);
     fetchReplies();
@@ -186,7 +189,11 @@ export default function PostDetailScreen() {
       const entries = all.map(r => [r.id, r.reply_count ?? 0]);
       if (postData) entries.push([post.id, postData.reply_count ?? all.length]);
       else entries.push([post.id, post.reply_count ?? all.length]);
-      setReplyCounts(Object.fromEntries(entries));
+      setReplyCounts(prev => {
+        const counts = { ...prev, ...Object.fromEntries(entries) };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+        return counts;
+      });
 
     }
   };
@@ -201,10 +208,23 @@ export default function PostDetailScreen() {
           setAllReplies(cached);
           const entries = cached.map((r: any) => [r.id, r.reply_count ?? 0]);
           entries.push([post.id, post.reply_count ?? cached.length]);
-          setReplyCounts(Object.fromEntries(entries));
+          setReplyCounts(prev => {
+            const counts = { ...prev, ...Object.fromEntries(entries) };
+            AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+            return counts;
+          });
 
         } catch (e) {
           console.error('Failed to parse cached replies', e);
+        }
+      }
+
+      const countStored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+      if (countStored) {
+        try {
+          setReplyCounts(prev => ({ ...prev, ...JSON.parse(countStored) }));
+        } catch (e) {
+          console.error('Failed to parse cached counts', e);
         }
       }
 
@@ -236,11 +256,15 @@ export default function PostDetailScreen() {
       return updated;
     });
     setAllReplies(prev => [...prev, newReply]);
-    setReplyCounts(prev => ({
-      ...prev,
-      [post.id]: (prev[post.id] || 0) + 1,
-      [newReply.id]: 0,
-    }));
+    setReplyCounts(prev => {
+      const counts = {
+        ...prev,
+        [post.id]: (prev[post.id] || 0) + 1,
+        [newReply.id]: 0,
+      };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -284,7 +308,9 @@ export default function PostDetailScreen() {
         setReplyCounts(prev => {
           const temp = prev[newReply.id] ?? 0;
           const { [newReply.id]: _omit, ...rest } = prev;
-          return { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+          const counts = { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
         });
 
       }

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 
 const CHILD_PREFIX = 'cached_child_replies_';
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 function timeAgo(dateString: string): string {
   const diff = Date.now() - new Date(dateString).getTime();
@@ -141,7 +142,18 @@ export default function ReplyDetailScreen() {
       let removed = descendants.size + 1;
       const { [id]: _omit, ...rest } = prev;
       descendants.forEach(d => delete rest[d]);
-      return { ...rest, [parent.id]: (prev[parent.id] || 0) - removed };
+      const counts: { [key: string]: number } = {
+        ...rest,
+        [parent.id]: (prev[parent.id] || 0) - removed,
+      };
+      ancestors.forEach(a => {
+        counts[a.id] = (counts[a.id] || prev[a.id] || 0) - removed;
+      });
+      if (originalPost) {
+        counts[originalPost.id] = (counts[originalPost.id] || prev[originalPost.id] || 0) - removed;
+      }
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
     });
 
     await supabase.from('replies').delete().eq('id', id);
@@ -174,7 +186,11 @@ export default function ReplyDetailScreen() {
         .single();
       const entries = all.map(r => [r.id, r.reply_count ?? 0]);
       if (postData) entries.push([parent.post_id, postData.reply_count ?? all.length]);
-      setReplyCounts(Object.fromEntries(entries));
+      setReplyCounts(prev => {
+        const counts = { ...prev, ...Object.fromEntries(entries) };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+        return counts;
+      });
 
     }
   };
@@ -188,12 +204,26 @@ export default function ReplyDetailScreen() {
           setReplies(cached);
           setAllReplies(cached);
           const entries = cached.map((r: any) => [r.id, r.reply_count ?? 0]);
-          setReplyCounts(prev => ({ ...prev, ...Object.fromEntries(entries) }));
+          setReplyCounts(prev => {
+            const counts = { ...prev, ...Object.fromEntries(entries) };
+            AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+            return counts;
+          });
 
         } catch (e) {
           console.error('Failed to parse cached replies', e);
         }
       }
+
+      const countStored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+      if (countStored) {
+        try {
+          setReplyCounts(prev => ({ ...prev, ...JSON.parse(countStored) }));
+        } catch (e) {
+          console.error('Failed to parse cached counts', e);
+        }
+      }
+
       fetchReplies();
     };
     loadCached();
@@ -236,11 +266,21 @@ export default function ReplyDetailScreen() {
       return updated;
     });
     setAllReplies(prev => [...prev, newReply]);
-    setReplyCounts(prev => ({
-      ...prev,
-      [parent.id]: (prev[parent.id] || 0) + 1,
-      [newReply.id]: 0,
-    }));
+    setReplyCounts(prev => {
+      const counts: { [key: string]: number } = {
+        ...prev,
+        [parent.id]: (prev[parent.id] || 0) + 1,
+        [newReply.id]: 0,
+      };
+      ancestors.forEach(a => {
+        counts[a.id] = (counts[a.id] || prev[a.id] || 0) + 1;
+      });
+      if (originalPost) {
+        counts[originalPost.id] = (counts[originalPost.id] || prev[originalPost.id] || 0) + 1;
+      }
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -286,7 +326,19 @@ export default function ReplyDetailScreen() {
         setReplyCounts(prev => {
           const temp = prev[newReply.id] ?? 0;
           const { [newReply.id]: _omit, ...rest } = prev;
-          return { ...rest, [data.id]: temp, [parent.id]: prev[parent.id] || 0 };
+          const counts: { [key: string]: number } = {
+            ...rest,
+            [data.id]: temp,
+            [parent.id]: prev[parent.id],
+          };
+          ancestors.forEach(a => {
+            if (prev[a.id] !== undefined) counts[a.id] = prev[a.id];
+          });
+          if (originalPost && prev[originalPost.id] !== undefined) {
+            counts[originalPost.id] = prev[originalPost.id];
+          }
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
         });
 
       }


### PR DESCRIPTION
## Summary
- persist reply counts to `AsyncStorage`
- restore counts when fetching posts or updating posts
- count nested replies for posts and replies and keep caches in sync

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*