### PR TITLE
Enable persistent reply counts in thread views

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -80,7 +80,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     });
     setReplyCounts(prev => {
       const { [id]: _removed, ...rest } = prev;
-
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
       return rest;
     });
     await supabase.from('posts').delete().eq('id', id);
@@ -92,15 +92,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const fetchPosts = async () => {
     const { data, error } = await supabase
       .from('posts')
-      .select('id, content, user_id, created_at, reply_count, profiles(username, display_name)')
+      .select(
+        'id, content, user_id, created_at, reply_count, profiles(username, display_name)',
+      )
       .order('created_at', { ascending: false });
 
     if (!error && data) {
       setPosts(data as Post[]);
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
       const entries = (data as any[]).map(p => [p.id, p.reply_count ?? 0]);
-      setReplyCounts(Object.fromEntries(entries));
-
+      const counts = Object.fromEntries(entries);
+      setReplyCounts(counts);
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
     }
   };
 
@@ -128,7 +131,11 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
-    setReplyCounts(prev => ({ ...prev, [newPost.id]: 0 }));
+    setReplyCounts(prev => {
+      const counts = { ...prev, [newPost.id]: 0 };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
 
     if (!hideInput) {
       setPostText('');
@@ -168,7 +175,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         });
         setReplyCounts(prev => {
           const { [newPost.id]: tempCount, ...rest } = prev;
-          return { ...rest, [data.id]: tempCount };
+          const counts = { ...rest, [data.id]: tempCount };
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
 
         });
       }
@@ -232,6 +241,17 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
   useFocusEffect(
     useCallback(() => {
+      const syncCounts = async () => {
+        const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+        if (stored) {
+          try {
+            setReplyCounts(JSON.parse(stored));
+          } catch (e) {
+            console.error('Failed to parse cached counts', e);
+          }
+        }
+      };
+      syncCounts();
       fetchPosts();
     }, []),
   );

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -14,13 +14,14 @@ import {
   Image,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useRoute, useNavigation } from '@react-navigation/native';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
 
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 function timeAgo(dateString: string): string {
   const diff = Date.now() - new Date(dateString).getTime();
@@ -137,7 +138,9 @@ export default function PostDetailScreen() {
       let removed = descendants.size + 1;
       const { [id]: _omit, ...rest } = prev;
       descendants.forEach(d => delete rest[d]);
-      return { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+      const counts = { ...rest, [post.id]: (prev[post.id] || 0) - removed };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
     });
     await supabase.from('replies').delete().eq('id', id);
     fetchReplies();
@@ -157,6 +160,23 @@ export default function PostDetailScreen() {
       hide.remove();
     };
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      const refreshCounts = async () => {
+        const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+        if (stored) {
+          try {
+            setReplyCounts(prev => ({ ...prev, ...JSON.parse(stored) }));
+          } catch (e) {
+            console.error('Failed to parse cached counts', e);
+          }
+        }
+      };
+      refreshCounts();
+      fetchReplies();
+    }, []),
+  );
 
 
 
@@ -186,7 +206,11 @@ export default function PostDetailScreen() {
       const entries = all.map(r => [r.id, r.reply_count ?? 0]);
       if (postData) entries.push([post.id, postData.reply_count ?? all.length]);
       else entries.push([post.id, post.reply_count ?? all.length]);
-      setReplyCounts(Object.fromEntries(entries));
+      setReplyCounts(prev => {
+        const counts = { ...prev, ...Object.fromEntries(entries) };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+        return counts;
+      });
 
     }
   };
@@ -194,6 +218,15 @@ export default function PostDetailScreen() {
   useEffect(() => {
     const loadCached = async () => {
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      const countStored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+      let storedCounts: { [key: string]: number } = {};
+      if (countStored) {
+        try {
+          storedCounts = JSON.parse(countStored);
+        } catch (e) {
+          console.error('Failed to parse cached counts', e);
+        }
+      }
       if (stored) {
         try {
           const cached = JSON.parse(stored);
@@ -201,11 +234,17 @@ export default function PostDetailScreen() {
           setAllReplies(cached);
           const entries = cached.map((r: any) => [r.id, r.reply_count ?? 0]);
           entries.push([post.id, post.reply_count ?? cached.length]);
-          setReplyCounts(Object.fromEntries(entries));
+          const counts = { ...storedCounts, ...Object.fromEntries(entries) };
+          setReplyCounts(counts);
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
 
         } catch (e) {
           console.error('Failed to parse cached replies', e);
         }
+      }
+
+      if (countStored && !stored) {
+        setReplyCounts(storedCounts);
       }
 
       fetchReplies();
@@ -236,11 +275,15 @@ export default function PostDetailScreen() {
       return updated;
     });
     setAllReplies(prev => [...prev, newReply]);
-    setReplyCounts(prev => ({
-      ...prev,
-      [post.id]: (prev[post.id] || 0) + 1,
-      [newReply.id]: 0,
-    }));
+    setReplyCounts(prev => {
+      const counts = {
+        ...prev,
+        [post.id]: (prev[post.id] || 0) + 1,
+        [newReply.id]: 0,
+      };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -284,7 +327,9 @@ export default function PostDetailScreen() {
         setReplyCounts(prev => {
           const temp = prev[newReply.id] ?? 0;
           const { [newReply.id]: _omit, ...rest } = prev;
-          return { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+          const counts = { ...rest, [data.id]: temp, [post.id]: prev[post.id] || 0 };
+          AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
         });
 
       }


### PR DESCRIPTION
## Summary
- keep reply counts in AsyncStorage on all screens
- load stored counts on focus so navigating back never resets the numbers
- refresh the feed's counts from storage whenever it gains focus

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*