### PR TITLE
Add heart icons

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -318,6 +318,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                   />
                   <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
                 </View>
+                <View style={styles.likeContainer}>
+                  <Ionicons name="heart-outline" size={12} color="red" />
+                </View>
               </View>
             </TouchableOpacity>
           );
@@ -371,6 +374,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  likeContainer: {
+    position: 'absolute',
+    bottom: 6,
+    left: '50%',
+    transform: [{ translateX: -6 }],
+  },
 });
 
 export default HomeScreen;

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -392,6 +392,9 @@ export default function PostDetailScreen() {
               />
               <Text style={styles.replyCount}>{replyCounts[post.id] || 0}</Text>
             </View>
+            <View style={styles.likeContainer}>
+              <Ionicons name="heart-outline" size={12} color="red" />
+            </View>
           </View>
         )}
         contentContainerStyle={{ paddingBottom: 100 }}
@@ -443,6 +446,9 @@ export default function PostDetailScreen() {
                       style={{ marginRight: 2 }}
                     />
                     <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
+                  </View>
+                  <View style={styles.likeContainer}>
+                    <Ionicons name="heart-outline" size={12} color="red" />
                   </View>
                 </View>
               </TouchableOpacity>
@@ -511,6 +517,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  likeContainer: {
+    position: 'absolute',
+    bottom: 6,
+    left: '50%',
+    transform: [{ translateX: -6 }],
+  },
   input: {
     backgroundColor: 'white',
     padding: 10,

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -43,19 +43,23 @@ export default function ProfileScreen() {
       <View style={styles.backButton}>
         <Button title="Back" onPress={() => navigation.goBack()} />
       </View>
-      <Text style={styles.username}>@{profile.username}</Text>
-      {profile.display_name && (
-        <Text style={styles.name}>{profile.display_name}</Text>
-      )}
+      <View style={styles.profileRow}>
+        {profileImageUri ? (
+          <Image source={{ uri: profileImageUri }} style={styles.avatar} />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        <View style={styles.textContainer}>
+          <Text style={styles.username}>@{profile.username}</Text>
+          {profile.display_name && (
+            <Text style={styles.name}>{profile.display_name}</Text>
+          )}
+        </View>
+      </View>
       <TouchableOpacity onPress={pickImage} style={styles.uploadLink}>
         <Text style={styles.uploadText}>Upload Profile Picture</Text>
       </TouchableOpacity>
-      {profileImageUri && (
-        <Image source={{ uri: profileImageUri }} style={styles.image} />
-      )}
-
     </View>
-
   );
 }
 
@@ -103,6 +107,5 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
   },
   uploadText: { color: 'white' },
-  image: { width: 100, height: 100, borderRadius: 50, marginTop: 20 },
 
 });

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -406,6 +406,9 @@ export default function ReplyDetailScreen() {
                   />
                   <Text style={styles.replyCount}>{replyCounts[originalPost.id] || 0}</Text>
                 </View>
+                <View style={styles.likeContainer}>
+                  <Ionicons name="heart-outline" size={12} color="red" />
+                </View>
               </View>
             )}
               {ancestors.map(a => {
@@ -449,6 +452,9 @@ export default function ReplyDetailScreen() {
                   />
                   <Text style={styles.replyCount}>{replyCounts[a.id] || 0}</Text>
                 </View>
+                <View style={styles.likeContainer}>
+                  <Ionicons name="heart-outline" size={12} color="red" />
+                </View>
               </View>
             );
           })}
@@ -476,16 +482,19 @@ export default function ReplyDetailScreen() {
                   <Text style={styles.timestamp}>{timeAgo(parent.created_at)}</Text>
                 </View>
               </View>
-            <View style={styles.replyCountContainer}>
-              <Ionicons
-                name="chatbubble-outline"
-                size={12}
-                color="#66538f"
-                style={{ marginRight: 2 }}
-              />
-              <Text style={styles.replyCount}>{replyCounts[parent.id] || 0}</Text>
-            </View>
-            </View>
+          <View style={styles.replyCountContainer}>
+            <Ionicons
+              name="chatbubble-outline"
+              size={12}
+              color="#66538f"
+              style={{ marginRight: 2 }}
+            />
+            <Text style={styles.replyCount}>{replyCounts[parent.id] || 0}</Text>
+          </View>
+          <View style={styles.likeContainer}>
+            <Ionicons name="heart-outline" size={12} color="red" />
+          </View>
+          </View>
           </>
         )}
         contentContainerStyle={{ paddingBottom: 100 }}
@@ -538,6 +547,9 @@ export default function ReplyDetailScreen() {
                     style={{ marginRight: 2 }}
                   />
                   <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
+                </View>
+                <View style={styles.likeContainer}>
+                  <Ionicons name="heart-outline" size={12} color="red" />
                 </View>
               </View>
             </TouchableOpacity>
@@ -615,6 +627,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  likeContainer: {
+    position: 'absolute',
+    bottom: 6,
+    left: '50%',
+    transform: [{ translateX: -6 }],
+  },
   input: {
     backgroundColor: 'white',
     padding: 10,


### PR DESCRIPTION
## Summary
- add outlined heart icon placeholder on post cards, reply cards, and nested reply cards
- position the icon at the center bottom of each card
- restore selecting a profile picture via expo-image-picker
- show selected picture beside the username on the Profile screen

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*