### PR TITLE
Add cross-account like functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql` and `sql/profiles.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
 
 
 3. Copy your project's URL and `anon` key into `lib/supabase.js`.

--- a/sql/likes.sql
+++ b/sql/likes.sql
@@ -1,0 +1,55 @@
+-- Setup likes table and triggers for like counts
+
+-- Add like_count columns if they don't already exist
+alter table public.posts add column if not exists like_count integer not null default 0;
+alter table public.replies add column if not exists like_count integer not null default 0;
+
+-- Table storing individual likes
+create table if not exists public.likes (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid not null references public.profiles(id) on delete cascade,
+    post_id uuid references public.posts(id) on delete cascade,
+    reply_id uuid references public.replies(id) on delete cascade,
+    created_at timestamptz not null default now(),
+    check (
+        (post_id is not null and reply_id is null) or
+        (post_id is null and reply_id is not null)
+    ),
+    unique (user_id, post_id, reply_id)
+);
+
+alter table public.likes enable row level security;
+create policy "Users can like" on public.likes
+  for insert with check (auth.uid() = user_id);
+create policy "Users can unlike" on public.likes
+  for delete using (auth.uid() = user_id);
+create policy "Anyone can read likes" on public.likes
+  for select using (true);
+
+create or replace function public.increment_like_count() returns trigger as $$
+begin
+  if (new.post_id is not null) then
+    update public.posts set like_count = like_count + 1 where id = new.post_id;
+  else
+    update public.replies set like_count = like_count + 1 where id = new.reply_id;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create or replace function public.decrement_like_count() returns trigger as $$
+begin
+  if (old.post_id is not null) then
+    update public.posts set like_count = like_count - 1 where id = old.post_id;
+  else
+    update public.replies set like_count = like_count - 1 where id = old.reply_id;
+  end if;
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger like_insert after insert on public.likes
+  for each row execute procedure public.increment_like_count();
+create trigger like_delete after delete on public.likes
+  for each row execute procedure public.decrement_like_count();
+


### PR DESCRIPTION
## Summary
- create `likes` table SQL with triggers for like counts
- update README with new setup step
- implement like button toggling and counts across Home/Post/Reply screens
- persist like state locally and sync with Supabase

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*
