### PR TITLE
Add persistent like functionality

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -20,6 +20,8 @@ import { colors } from '../styles/colors';
 
 const STORAGE_KEY = 'cached_posts';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
+const LIKE_STORAGE_KEY = 'cached_like_counts';
+const LIKED_STORAGE_KEY = 'liked_posts';
 
 type Post = {
   id: string;
@@ -28,6 +30,7 @@ type Post = {
   user_id: string;
   created_at: string;
   reply_count?: number;
+  like_count?: number;
   profiles?: {
     username: string | null;
     display_name: string | null;
@@ -60,6 +63,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
+  const [likeCounts, setLikeCounts] = useState<{ [key: string]: number }>({});
+  const [likedPosts, setLikedPosts] = useState<{ [key: string]: boolean }>({});
 
 
   const confirmDeletePost = (id: string) => {
@@ -87,6 +92,33 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     await supabase.from('posts').delete().eq('id', id);
   };
 
+  const toggleLike = async (postId: string) => {
+    if (!user) return;
+    const liked = likedPosts[postId];
+    setLikedPosts(prev => {
+      const updated = { ...prev, [postId]: !liked };
+      AsyncStorage.setItem(LIKED_STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+    setLikeCounts(prev => {
+      const updated = {
+        ...prev,
+        [postId]: (prev[postId] || 0) + (liked ? -1 : 1),
+      };
+      AsyncStorage.setItem(LIKE_STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+    if (liked) {
+      await supabase
+        .from('likes')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('post_id', postId);
+    } else {
+      await supabase.from('likes').insert([{ user_id: user.id, post_id: postId }]);
+    }
+  };
+
 
 
 
@@ -94,17 +126,34 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { data, error } = await supabase
       .from('posts')
       .select(
-        'id, content, user_id, created_at, reply_count, profiles(username, display_name)',
+        'id, content, user_id, created_at, reply_count, like_count, profiles(username, display_name)',
       )
       .order('created_at', { ascending: false });
 
     if (!error && data) {
       setPosts(data as Post[]);
       AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-      const entries = (data as any[]).map(p => [p.id, p.reply_count ?? 0]);
-      const counts = Object.fromEntries(entries);
+      const replyEntries = (data as any[]).map(p => [p.id, p.reply_count ?? 0]);
+      const likeEntries = (data as any[]).map(p => [p.id, p.like_count ?? 0]);
+      const counts = Object.fromEntries(replyEntries);
+      const likeCountsObj = Object.fromEntries(likeEntries);
       setReplyCounts(counts);
+      setLikeCounts(likeCountsObj);
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      AsyncStorage.setItem(LIKE_STORAGE_KEY, JSON.stringify(likeCountsObj));
+
+      if (user) {
+        const { data: likedData } = await supabase
+          .from('likes')
+          .select('post_id')
+          .eq('user_id', user.id);
+        const likedMap: { [key: string]: boolean } = {};
+        likedData?.forEach(l => {
+          if (l.post_id) likedMap[l.post_id] = true;
+        });
+        setLikedPosts(likedMap);
+        AsyncStorage.setItem(LIKED_STORAGE_KEY, JSON.stringify(likedMap));
+      }
     }
   };
 
@@ -120,6 +169,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       user_id: user.id,
       created_at: new Date().toISOString(),
       reply_count: 0,
+      like_count: 0,
       profiles: {
         username: profile.username,
         display_name: profile.display_name,
@@ -136,6 +186,16 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       const counts = { ...prev, [newPost.id]: 0 };
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
+    });
+    setLikeCounts(prev => {
+      const counts = { ...prev, [newPost.id]: 0 };
+      AsyncStorage.setItem(LIKE_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
+    setLikedPosts(prev => {
+      const liked = { ...prev, [newPost.id]: false };
+      AsyncStorage.setItem(LIKED_STORAGE_KEY, JSON.stringify(liked));
+      return liked;
     });
 
     if (!hideInput) {
@@ -181,6 +241,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           return counts;
 
         });
+        setLikeCounts(prev => {
+          const { [newPost.id]: tempLike, ...rest } = prev;
+          const counts = { ...rest, [data.id]: tempLike };
+          AsyncStorage.setItem(LIKE_STORAGE_KEY, JSON.stringify(counts));
+          return counts;
+        });
+        setLikedPosts(prev => {
+          const { [newPost.id]: tempLiked, ...rest } = prev;
+          const liked = { ...rest, [data.id]: tempLiked };
+          AsyncStorage.setItem(LIKED_STORAGE_KEY, JSON.stringify(liked));
+          return liked;
+        });
       }
 
       // Refresh from the server in the background to stay in sync
@@ -196,6 +268,16 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       setReplyCounts(prev => {
         const { [newPost.id]: _omit, ...rest } = prev;
         AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
+        return rest;
+      });
+      setLikeCounts(prev => {
+        const { [newPost.id]: _omit, ...rest } = prev;
+        AsyncStorage.setItem(LIKE_STORAGE_KEY, JSON.stringify(rest));
+        return rest;
+      });
+      setLikedPosts(prev => {
+        const { [newPost.id]: _omit, ...rest } = prev;
+        AsyncStorage.setItem(LIKED_STORAGE_KEY, JSON.stringify(rest));
         return rest;
       });
 
@@ -220,7 +302,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           setPosts(cached);
           const entries = cached.map((p: any) => [p.id, p.reply_count ?? 0]);
           setReplyCounts(Object.fromEntries(entries));
-
+          const likeEntries = cached.map((p: any) => [p.id, p.like_count ?? 0]);
+          setLikeCounts(Object.fromEntries(likeEntries));
         } catch (e) {
           console.error('Failed to parse cached posts', e);
         }
@@ -231,6 +314,22 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           setReplyCounts(JSON.parse(countStored));
         } catch (e) {
           console.error('Failed to parse cached counts', e);
+        }
+      }
+      const likeStored = await AsyncStorage.getItem(LIKE_STORAGE_KEY);
+      if (likeStored) {
+        try {
+          setLikeCounts(prev => ({ ...prev, ...JSON.parse(likeStored) }));
+        } catch (e) {
+          console.error('Failed to parse cached like counts', e);
+        }
+      }
+      const likedStored = await AsyncStorage.getItem(LIKED_STORAGE_KEY);
+      if (likedStored) {
+        try {
+          setLikedPosts(JSON.parse(likedStored));
+        } catch (e) {
+          console.error('Failed to parse cached liked posts', e);
         }
       }
 
@@ -249,6 +348,22 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
             setReplyCounts(JSON.parse(stored));
           } catch (e) {
             console.error('Failed to parse cached counts', e);
+          }
+        }
+        const likeStored = await AsyncStorage.getItem(LIKE_STORAGE_KEY);
+        if (likeStored) {
+          try {
+            setLikeCounts(JSON.parse(likeStored));
+          } catch (e) {
+            console.error('Failed to parse cached like counts', e);
+          }
+        }
+        const likedStored = await AsyncStorage.getItem(LIKED_STORAGE_KEY);
+        if (likedStored) {
+          try {
+            setLikedPosts(JSON.parse(likedStored));
+          } catch (e) {
+            console.error('Failed to parse cached liked posts', e);
           }
         }
       };
@@ -318,6 +433,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                   />
                   <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
                 </View>
+                <TouchableOpacity
+                  style={styles.likeContainer}
+                  onPress={() => toggleLike(item.id)}
+                >
+                  <Ionicons
+                    name={likedPosts[item.id] ? 'heart' : 'heart-outline'}
+                    size={12}
+                    color="red"
+                    style={{ marginRight: 2 }}
+                  />
+                  <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                </TouchableOpacity>
               </View>
             </TouchableOpacity>
           );
@@ -371,6 +498,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  likeContainer: {
+    position: 'absolute',
+    bottom: 6,
+    left: '50%',
+    transform: [{ translateX: -6 }],
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
 });
 
 export default HomeScreen;

--- a/sql/likes.sql
+++ b/sql/likes.sql
@@ -1,0 +1,57 @@
+-- Adds like support for posts and replies
+
+-- Add like_count columns if they don't exist
+alter table public.posts add column if not exists like_count integer not null default 0;
+alter table public.replies add column if not exists like_count integer not null default 0;
+
+-- Table to store per-user likes
+create table if not exists public.likes (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references public.profiles(id) on delete cascade,
+    post_id uuid references public.posts(id) on delete cascade,
+    reply_id uuid references public.replies(id) on delete cascade,
+    created_at timestamptz not null default now(),
+    constraint one_target check ((post_id is not null) <> (reply_id is not null)),
+    constraint unique_post_like unique (user_id, post_id),
+    constraint unique_reply_like unique (user_id, reply_id)
+);
+
+alter table public.likes enable row level security;
+
+create policy "Users can like" on public.likes
+  for insert with check (auth.uid() = user_id);
+create policy "Users can unlike" on public.likes
+  for delete using (auth.uid() = user_id);
+create policy "Anyone can read likes" on public.likes
+  for select using (true);
+
+-- Trigger functions to maintain like counts
+create or replace function public.increment_like_count() returns trigger as $$
+begin
+  if new.post_id is not null then
+    update public.posts set like_count = like_count + 1 where id = new.post_id;
+  elsif new.reply_id is not null then
+    update public.replies set like_count = like_count + 1 where id = new.reply_id;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create or replace function public.decrement_like_count() returns trigger as $$
+begin
+  if old.post_id is not null then
+    update public.posts set like_count = like_count - 1 where id = old.post_id;
+  elsif old.reply_id is not null then
+    update public.replies set like_count = like_count - 1 where id = old.reply_id;
+  end if;
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger like_insert
+after insert on public.likes
+for each row execute procedure public.increment_like_count();
+
+create trigger like_delete
+after delete on public.likes
+for each row execute procedure public.decrement_like_count();


### PR DESCRIPTION
## Summary
- create `likes.sql` for persistent like counts
- track likes in HomeScreen, PostDetailScreen, and ReplyDetailScreen
- toggle heart icons and update like counts across sessions

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*