### PR TITLE
Improve like updates on nested threads

### DIFF
--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -106,28 +106,44 @@ export default function ReplyDetailScreen() {
     navigation.goBack();
   };
 
+  const refreshLikeCount = async (id: string, isPost = false) => {
+    const { data, error } = await supabase
+      .from(isPost ? 'posts' : 'replies')
+      .select('like_count')
+      .eq('id', id)
+      .single();
+    if (!error && data) {
+      setLikeCounts(prev => {
+        const counts = { ...prev, [id]: data.like_count ?? 0 };
+        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
+        return counts;
+      });
+    }
+  };
+
   const toggleLike = async (id: string, isPost = false) => {
     if (!user) return;
     const key = id;
-    const isLiked = liked[key];
-    setLiked(prev => ({ ...prev, [key]: !isLiked }));
-    setLikeCounts(prev => ({
-      ...prev,
-      [key]: (prev[key] || 0) + (isLiked ? -1 : 1),
-    }));
-    AsyncStorage.setItem(
-      LIKE_COUNT_KEY,
-      JSON.stringify({ ...likeCounts, [key]: (likeCounts[key] || 0) + (isLiked ? -1 : 1) }),
-    );
-    AsyncStorage.setItem(
-      LIKE_STATE_KEY,
-      JSON.stringify({ ...liked, [key]: !isLiked }),
-    );
+    const isLiked = likedItems[key];
+    setLikedItems(prev => {
+      const updated = { ...prev, [key]: !isLiked };
+      AsyncStorage.setItem(
+        `${LIKED_KEY_PREFIX}${user.id}`,
+        JSON.stringify(updated),
+      );
+      return updated;
+    });
+    setLikeCounts(prev => {
+      const counts = { ...prev, [key]: (prev[key] || 0) + (isLiked ? -1 : 1) };
+      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
+      return counts;
+    });
     if (isLiked) {
       await supabase.from('likes').delete().match(isPost ? { post_id: id, user_id: user.id } : { reply_id: id, user_id: user.id });
     } else {
       await supabase.from('likes').insert([isPost ? { post_id: id, user_id: user.id } : { reply_id: id, user_id: user.id }]);
     }
+    refreshLikeCount(id, isPost);
   };
 
   const confirmDeleteReply = (id: string) => {
@@ -252,37 +268,16 @@ export default function ReplyDetailScreen() {
             const key = l.post_id || l.reply_id;
             map[key] = true;
           });
-          setLiked(map);
-          AsyncStorage.setItem(LIKE_STATE_KEY, JSON.stringify(map));
+          setLikedItems(map);
+          AsyncStorage.setItem(
+            `${LIKED_KEY_PREFIX}${user.id}`,
+            JSON.stringify(map),
+          );
         }
       }
 
       
-      if (postData) likeEntries.push([parent.post_id, postData.like_count ?? 0]);
-      setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
-
-      if (user) {
-        const { data: likeData } = await supabase
-          .from('likes')
-          .select('post_id, reply_id')
-          .eq('user_id', user.id);
-        if (likeData) {
-          const likedObj: { [key: string]: boolean } = {};
-          likeData.forEach(l => {
-            if (l.post_id) likedObj[l.post_id] = true;
-            if (l.reply_id) likedObj[l.reply_id] = true;
-          });
-          setLikedItems(likedObj);
-          AsyncStorage.setItem(
-            `${LIKED_KEY_PREFIX}${user.id}`,
-            JSON.stringify(likedObj),
-          );
-        }
-      }
+      // like counts and liked items already refreshed above
 
 
     }
@@ -343,21 +338,20 @@ export default function ReplyDetailScreen() {
       }
 
      
-      if (likeStored) {
+      // Legacy storage key for liked state; retained for backward compatibility
+      const legacyLiked = await AsyncStorage.getItem('LIKE_STATE_KEY');
+      if (legacyLiked) {
         try {
-          setLikeCounts(JSON.parse(likeStored));
-        } catch (e) {
-          console.error('Failed to parse cached like counts', e);
+          const parsed = JSON.parse(legacyLiked);
+            setLikedItems(parsed);
+            AsyncStorage.setItem(
+              `${LIKED_KEY_PREFIX}${user.id}`,
+              JSON.stringify(parsed),
+            );
+          } catch (e) {
+            console.error('Failed to parse cached likes', e);
+          }
         }
-      }
-      const likedStored = await AsyncStorage.getItem(LIKE_STATE_KEY);
-      if (likedStored) {
-        try {
-          setLiked(JSON.parse(likedStored));
-        } catch (e) {
-          console.error('Failed to parse cached likes', e);
-        }
-      }
 
       
 


### PR DESCRIPTION
## Summary
- refresh like counts from Supabase after toggling likes
- keep stored counts merged when loading nested reply screens
- remove duplicate like count updates

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX without --jsx flag)*