### PR TITLE
Persist like counts across screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './AuthContext';
 import Navigator from './Navigator';
+import { LikeProvider } from './LikeContext';
 
 import { Buffer } from 'buffer';
 import process from 'process';
@@ -12,9 +13,11 @@ global.process = process;
 export default function App() {
   return (
     <AuthProvider>
-      <NavigationContainer>
-        <Navigator />
-      </NavigationContainer>
+      <LikeProvider>
+        <NavigationContainer>
+          <Navigator />
+        </NavigationContainer>
+      </LikeProvider>
     </AuthProvider>
   );
 }

--- a/LikeContext.tsx
+++ b/LikeContext.tsx
@@ -1,0 +1,92 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { supabase } from './lib/supabase';
+import { useAuth } from './AuthContext';
+
+const LIKE_COUNT_KEY = 'cached_like_counts';
+const LIKED_KEY_PREFIX = 'cached_likes_';
+
+interface LikeContextType {
+  likeCounts: Record<string, number>;
+  likedItems: Record<string, boolean>;
+  setLikeCounts: (counts: Record<string, number>) => void;
+  setLikedItems: (items: Record<string, boolean>) => void;
+  toggleLike: (id: string, isPost: boolean) => Promise<void>;
+  refreshLike: (id: string, isPost: boolean) => Promise<void>;
+}
+
+const LikeContext = createContext<LikeContextType | undefined>(undefined);
+
+export const LikeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user } = useAuth() as any;
+  const [likeCounts, internalSetCounts] = useState<Record<string, number>>({});
+  const [likedItems, internalSetLiked] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const load = async () => {
+      const storedCounts = await AsyncStorage.getItem(LIKE_COUNT_KEY);
+      if (storedCounts) {
+        try { internalSetCounts(JSON.parse(storedCounts)); } catch {}
+      }
+      if (user) {
+        const storedLiked = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
+        if (storedLiked) {
+          try { internalSetLiked(JSON.parse(storedLiked)); } catch {}
+        }
+      } else {
+        internalSetLiked({});
+      }
+    };
+    load();
+  }, [user]);
+
+  const setLikeCounts = (counts: Record<string, number>) => {
+    internalSetCounts(counts);
+    AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
+  };
+
+  const setLikedItems = (items: Record<string, boolean>) => {
+    internalSetLiked(items);
+    if (user) {
+      AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user.id}`, JSON.stringify(items));
+    }
+  };
+
+  const refreshLike = async (id: string, isPost: boolean) => {
+    const { data } = await supabase
+      .from(isPost ? 'posts' : 'replies')
+      .select('like_count')
+      .eq('id', id)
+      .single();
+    if (data) {
+      setLikeCounts({ ...likeCounts, [id]: data.like_count ?? 0 });
+    }
+  };
+
+  const toggleLike = async (id: string, isPost: boolean) => {
+    if (!user) return;
+    const liked = likedItems[id];
+    const newCount = (likeCounts[id] || 0) + (liked ? -1 : 1);
+    setLikedItems({ ...likedItems, [id]: !liked });
+    setLikeCounts({ ...likeCounts, [id]: newCount });
+
+    if (liked) {
+      await supabase.from('likes').delete().match({ user_id: user.id, [isPost ? 'post_id' : 'reply_id']: id });
+    } else {
+      await supabase.from('likes').insert({ user_id: user.id, [isPost ? 'post_id' : 'reply_id']: id });
+    }
+    await refreshLike(id, isPost);
+  };
+
+  return (
+    <LikeContext.Provider value={{ likeCounts, likedItems, setLikeCounts, setLikedItems, toggleLike, refreshLike }}>
+      {children}
+    </LikeContext.Provider>
+  );
+};
+
+export const useLikeContext = () => {
+  const ctx = useContext(LikeContext);
+  if (!ctx) throw new Error('useLikeContext must be used within LikeProvider');
+  return ctx;
+};

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -16,6 +16,7 @@ import { useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
+import { useLikeContext } from '../../LikeContext';
 import { colors } from '../styles/colors';
 
 const STORAGE_KEY = 'cached_posts';
@@ -64,8 +65,13 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
-  const [likeCounts, setLikeCounts] = useState<{ [key: string]: number }>({});
-  const [likedPosts, setLikedPosts] = useState<{ [key: string]: boolean }>({});
+  const {
+    likeCounts,
+    setLikeCounts,
+    likedItems,
+    setLikedItems,
+    toggleLike,
+  } = useLikeContext();
 
 
 
@@ -91,43 +97,14 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
       return rest;
     });
-    setLikeCounts(prev => {
-      const { [id]: _removed, ...rest } = prev;
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(rest));
-      return rest;
-    });
-    setLikedPosts(prev => {
-      const { [id]: _omit, ...rest } = prev;
-      AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user?.id}`, JSON.stringify(rest));
-      return rest;
-    });
+    const { [id]: _removed, ...restCounts } = likeCounts;
+    setLikeCounts(restCounts);
+    const { [id]: _omit, ...restLiked } = likedItems;
+    setLikedItems(restLiked);
     await supabase.from('posts').delete().eq('id', id);
   };
 
-  const toggleLike = async (id: string) => {
-    if (!user) return;
-    const liked = likedPosts[id];
-    setLikedPosts(prev => {
-      const updated = { ...prev, [id]: !liked };
-      AsyncStorage.setItem(
-        `${LIKED_KEY_PREFIX}${user.id}`,
-        JSON.stringify(updated),
-      );
-      return updated;
-    });
-    setLikeCounts(prev => {
-      const count = (prev[id] || 0) + (liked ? -1 : 1);
-      const counts = { ...prev, [id]: count };
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-      return counts;
-    });
-    if (liked) {
-      await supabase.from('likes').delete().match({ user_id: user.id, post_id: id });
-    } else {
-      await supabase.from('likes').insert({ user_id: user.id, post_id: id });
 
-    }
-  };
 
 
 
@@ -150,7 +127,6 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       const likeEntries = (data as any[]).map(p => [p.id, p.like_count ?? 0]);
       const likeMap = Object.fromEntries(likeEntries);
       setLikeCounts(likeMap);
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
 
       if (user) {
         const { data: likedData } = await supabase
@@ -163,11 +139,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           likedData.forEach(l => {
             if (l.post_id) likedObj[l.post_id] = true;
           });
-          setLikedPosts(likedObj);
-          AsyncStorage.setItem(
-            `${LIKED_KEY_PREFIX}${user.id}`,
-            JSON.stringify(likedObj),
-          );
+          setLikedItems(likedObj);
         }
 
       }
@@ -204,11 +176,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    setLikeCounts(prev => {
-      const counts = { ...prev, [newPost.id]: 0 };
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-      return counts;
-    });
+    setLikeCounts({ ...likeCounts, [newPost.id]: 0 });
 
     if (!hideInput) {
       setPostText('');
@@ -252,19 +220,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
           return counts;
         });
-        setLikeCounts(prev => {
-          const temp = prev[newPost.id] ?? 0;
-          const { [newPost.id]: _omit, ...rest } = prev;
-          const counts = { ...rest, [data.id]: temp };
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
-        setLikeCounts(prev => {
-          const { [newPost.id]: tempLike, ...rest } = prev;
-          const counts = { ...rest, [data.id]: tempLike ?? 0 };
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
+        const temp = likeCounts[newPost.id] ?? 0;
+        const { [newPost.id]: _omit, ...rest } = likeCounts;
+        setLikeCounts({ ...rest, [data.id]: temp });
       }
 
       // Refresh from the server in the background to stay in sync
@@ -282,11 +240,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
         return rest;
       });
-      setLikeCounts(prev => {
-        const { [newPost.id]: _omit, ...rest } = prev;
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(rest));
-        return rest;
-      });
+      const { [newPost.id]: _omit, ...rest } = likeCounts;
+      setLikeCounts(rest);
 
       // Log the failure and surface it to the user
       console.error('Failed to post:', error?.message);
@@ -336,7 +291,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
         if (likedStored) {
           try {
-            setLikedPosts(JSON.parse(likedStored));
+            setLikedItems(JSON.parse(likedStored));
           } catch (e) {
             console.error('Failed to parse cached likes', e);
           }
@@ -373,7 +328,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
           if (likedStored) {
             try {
-              setLikedPosts(JSON.parse(likedStored));
+              setLikedItems(JSON.parse(likedStored));
             } catch (e) {
               console.error('Failed to parse cached likes', e);
             }
@@ -449,10 +404,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                 </View>
                 <TouchableOpacity
                   style={styles.likeContainer}
-                  onPress={() => toggleLike(item.id)}
+                  onPress={() => toggleLike(item.id, true)}
                 >
                   <Ionicons
-                    name={likedPosts[item.id] ? 'heart' : 'heart-outline'}
+                    name={likedItems[item.id] ? 'heart' : 'heart-outline'}
 
                     size={12}
                     color="red"

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -20,6 +20,7 @@ import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/nativ
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
+import { useLikeContext } from '../../LikeContext';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -82,8 +83,13 @@ export default function PostDetailScreen() {
   const [replies, setReplies] = useState<Reply[]>([]);
   const [allReplies, setAllReplies] = useState<Reply[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
-  const [likeCounts, setLikeCounts] = useState<{ [key: string]: number }>({});
-  const [likedItems, setLikedItems] = useState<{ [key: string]: boolean }>({});
+  const {
+    likeCounts,
+    setLikeCounts,
+    likedItems,
+    setLikedItems,
+    toggleLike,
+  } = useLikeContext();
 
   const [keyboardOffset, setKeyboardOffset] = useState(0);
 
@@ -103,50 +109,6 @@ export default function PostDetailScreen() {
     navigation.goBack();
   };
 
-  const refreshLikeCount = async (id: string, isPost: boolean) => {
-    const { data } = await supabase
-      .from(isPost ? 'posts' : 'replies')
-      .select('like_count')
-      .eq('id', id)
-      .single();
-    if (data) {
-      setLikeCounts(prev => {
-        const counts = { ...prev, [id]: data.like_count ?? 0 };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
-    }
-  };
-
-  const toggleLike = async (id: string, isPost: boolean) => {
-    if (!user) return;
-    const liked = likedItems[id];
-    setLikedItems(prev => {
-      const updated = { ...prev, [id]: !liked };
-      AsyncStorage.setItem(
-        `${LIKED_KEY_PREFIX}${user.id}`,
-        JSON.stringify(updated),
-      );
-      return updated;
-    });
-    setLikeCounts(prev => {
-      const count = (prev[id] || 0) + (liked ? -1 : 1);
-      const counts = { ...prev, [id]: count };
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-      return counts;
-    });
-    if (liked) {
-      await supabase
-        .from('likes')
-        .delete()
-        .match({ user_id: user.id, [isPost ? 'post_id' : 'reply_id']: id });
-    } else {
-      await supabase
-        .from('likes')
-        .insert({ user_id: user.id, [isPost ? 'post_id' : 'reply_id']: id });
-    }
-    await refreshLikeCount(id, isPost);
-  };
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
@@ -196,16 +158,10 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    setLikeCounts(prev => {
-      const { [id]: _om, ...rest } = prev;
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(rest));
-      return rest;
-    });
-    setLikedItems(prev => {
-      const { [id]: _om, ...rest } = prev;
-      AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user?.id}`, JSON.stringify(rest));
-      return rest;
-    });
+    const { [id]: _om, ...restCounts } = likeCounts;
+    setLikeCounts(restCounts);
+    const { [id]: _om2, ...restLiked } = likedItems;
+    setLikedItems(restLiked);
     await supabase.from('replies').delete().eq('id', id);
     fetchReplies();
   };
@@ -239,7 +195,7 @@ export default function PostDetailScreen() {
         const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
         if (likeStored) {
           try {
-            setLikeCounts(prev => ({ ...prev, ...JSON.parse(likeStored) }));
+            setLikeCounts({ ...likeCounts, ...JSON.parse(likeStored) });
           } catch (e) {
             console.error('Failed to parse cached like counts', e);
           }
@@ -302,11 +258,7 @@ export default function PostDetailScreen() {
         .single();
       if (postLike) likeEntries.push([post.id, postLike.like_count ?? 0]);
       else likeEntries.push([post.id, post.like_count ?? 0]);
-      setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
+      setLikeCounts({ ...likeCounts, ...Object.fromEntries(likeEntries) });
 
       if (user) {
         const { data: likedData } = await supabase
@@ -330,11 +282,7 @@ export default function PostDetailScreen() {
       
       if (postData) likeEntries.push([post.id, postData.like_count ?? 0]);
       else likeEntries.push([post.id, post.like_count ?? 0]);
-      setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
+      setLikeCounts({ ...likeCounts, ...Object.fromEntries(likeEntries) });
 
       if (user) {
         const { data: likeData } = await supabase
@@ -386,7 +334,6 @@ export default function PostDetailScreen() {
           likeEntries.push([post.id, post.like_count ?? 0]);
           const likeCountsObj = Object.fromEntries(likeEntries);
           setLikeCounts(likeCountsObj);
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeCountsObj));
 
 
         } catch (e) {
@@ -477,12 +424,7 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    setLikeCounts(prev => {
-      const counts = { ...prev, [newReply.id]: 0 };
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-      return counts;
-
-    });
+    setLikeCounts({ ...likeCounts, [newReply.id]: 0 });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -530,13 +472,9 @@ export default function PostDetailScreen() {
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
           return counts;
         });
-        setLikeCounts(prev => {
-          const temp = prev[newReply.id] ?? 0;
-          const { [newReply.id]: _omit, ...rest } = prev;
-          const counts = { ...rest, [data.id]: temp };
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
+        const tempLike = likeCounts[newReply.id] ?? 0;
+        const { [newReply.id]: _omit, ...restLikes } = likeCounts;
+        setLikeCounts({ ...restLikes, [data.id]: tempLike });
 
       }
 

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -20,6 +20,7 @@ import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/nativ
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
+import { useLikeContext } from '../../LikeContext';
 
 const CHILD_PREFIX = 'cached_child_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -85,8 +86,14 @@ export default function ReplyDetailScreen() {
   const [replies, setReplies] = useState<Reply[]>([]);
   const [allReplies, setAllReplies] = useState<Reply[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
-  const [likeCounts, setLikeCounts] = useState<{ [key: string]: number }>({});
-  const [likedItems, setLikedItems] = useState<{ [key: string]: boolean }>({});
+  const {
+    likeCounts,
+    setLikeCounts,
+    likedItems,
+    setLikedItems,
+    toggleLike,
+    refreshLike,
+  } = useLikeContext();
 
   const [keyboardOffset, setKeyboardOffset] = useState(0);
 
@@ -106,21 +113,6 @@ export default function ReplyDetailScreen() {
     navigation.goBack();
   };
 
-  const refreshLikeCount = async (id: string, isPost: boolean) => {
-    const { data } = await supabase
-      .from(isPost ? 'posts' : 'replies')
-      .select('like_count')
-      .eq('id', id)
-      .single();
-    if (data) {
-      setLikeCounts(prev => {
-        const counts = { ...prev, [id]: data.like_count ?? 0 };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
-    }
-  };
-
   const refreshChainLikes = async () => {
     const replyIds = [parent.id, ...ancestors.map(a => a.id)];
     if (replyIds.length) {
@@ -130,11 +122,7 @@ export default function ReplyDetailScreen() {
         .in('id', replyIds);
       if (data) {
         const entries = data.map(r => [r.id, r.like_count ?? 0]);
-        setLikeCounts(prev => {
-          const counts = { ...prev, ...Object.fromEntries(entries) } as Record<string, number>;
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
+        setLikeCounts({ ...likeCounts, ...Object.fromEntries(entries) });
       }
     }
     if (originalPost) {
@@ -144,44 +132,11 @@ export default function ReplyDetailScreen() {
         .eq('id', originalPost.id)
         .single();
       if (data) {
-        setLikeCounts(prev => {
-          const counts = { ...prev, [originalPost.id]: data.like_count ?? 0 };
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
+        setLikeCounts({ ...likeCounts, [originalPost.id]: data.like_count ?? 0 });
       }
     }
   };
 
-  const toggleLike = async (id: string, isPost = false) => {
-    if (!user) return;
-    const key = id;
-    const isLiked = likedItems[key];
-    setLikedItems(prev => {
-      const updated = { ...prev, [key]: !isLiked };
-      AsyncStorage.setItem(
-        `${LIKED_KEY_PREFIX}${user.id}`,
-        JSON.stringify(updated),
-      );
-      return updated;
-    });
-    setLikeCounts(prev => {
-      const counts = { ...prev, [key]: (prev[key] || 0) + (isLiked ? -1 : 1) };
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-      return counts;
-    });
-    if (isLiked) {
-      await supabase
-        .from('likes')
-        .delete()
-        .match(isPost ? { post_id: id, user_id: user.id } : { reply_id: id, user_id: user.id });
-    } else {
-      await supabase
-        .from('likes')
-        .insert([isPost ? { post_id: id, user_id: user.id } : { reply_id: id, user_id: user.id }]);
-    }
-    await refreshLikeCount(id, isPost);
-  };
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
@@ -233,16 +188,10 @@ export default function ReplyDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    setLikeCounts(prev => {
-      const { [id]: _omit, ...rest } = prev;
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(rest));
-      return rest;
-    });
-    setLikedItems(prev => {
-      const { [id]: _o, ...rest } = prev;
-      AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user?.id}`, JSON.stringify(rest));
-      return rest;
-    });
+    const { [id]: _omit, ...restCounts } = likeCounts;
+    setLikeCounts(restCounts);
+    const { [id]: _o, ...restLiked } = likedItems;
+    setLikedItems(restLiked);
 
     await supabase.from('replies').delete().eq('id', id);
     fetchReplies();
@@ -289,11 +238,7 @@ export default function ReplyDetailScreen() {
         .eq('id', parent.post_id)
         .single();
       if (postLike) likeEntries.push([parent.post_id, postLike.like_count ?? 0]);
-      setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
+      setLikeCounts({ ...likeCounts, ...Object.fromEntries(likeEntries) });
 
       if (user) {
         const { data: likedData } = await supabase
@@ -307,20 +252,12 @@ export default function ReplyDetailScreen() {
             map[key] = true;
           });
           setLikedItems(map);
-          AsyncStorage.setItem(
-            `${LIKED_KEY_PREFIX}${user.id}`,
-            JSON.stringify(map),
-          );
         }
       }
 
       
       if (postData) likeEntries.push([parent.post_id, postData.like_count ?? 0]);
-      setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
+      setLikeCounts({ ...likeCounts, ...Object.fromEntries(likeEntries) });
 
       if (user) {
         const { data: likeData } = await supabase
@@ -334,10 +271,6 @@ export default function ReplyDetailScreen() {
             if (l.reply_id) likedObj[l.reply_id] = true;
           });
           setLikedItems(likedObj);
-          AsyncStorage.setItem(
-            `${LIKED_KEY_PREFIX}${user.id}`,
-            JSON.stringify(likedObj),
-          );
         }
       }
 
@@ -371,8 +304,7 @@ export default function ReplyDetailScreen() {
 
           const likeEntries = cached.map((r: any) => [r.id, r.like_count ?? 0]);
           const likeObj = Object.fromEntries(likeEntries);
-          setLikeCounts(prev => ({ ...prev, ...likeObj }));
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeObj));
+          setLikeCounts({ ...likeCounts, ...likeObj });
 
 
 
@@ -384,7 +316,7 @@ export default function ReplyDetailScreen() {
       }
       if (likeStored) {
         try {
-          setLikeCounts(prev => ({ ...prev, ...JSON.parse(likeStored) }));
+          setLikeCounts({ ...likeCounts, ...JSON.parse(likeStored) });
         } catch (e) {
           console.error('Failed to parse cached like counts', e);
         }
@@ -445,7 +377,7 @@ export default function ReplyDetailScreen() {
         const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
         if (likeStored) {
           try {
-            setLikeCounts(prev => ({ ...prev, ...JSON.parse(likeStored) }));
+            setLikeCounts({ ...likeCounts, ...JSON.parse(likeStored) });
           } catch (e) {
             console.error('Failed to parse cached like counts', e);
           }
@@ -516,11 +448,7 @@ export default function ReplyDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    setLikeCounts(prev => {
-      const counts = { ...prev, [newReply.id]: 0 };
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify({ ...likeCounts, ...counts }));
-      return { ...prev, [newReply.id]: 0 };
-    });
+    setLikeCounts({ ...likeCounts, [newReply.id]: 0 });
     setReplyText('');
 
     let { data, error } = await supabase
@@ -571,14 +499,9 @@ export default function ReplyDetailScreen() {
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
           return counts;
         });
-        setLikeCounts(prev => {
-          const temp = prev[newReply.id] ?? 0;
-          const { [newReply.id]: _o, ...rest } = prev;
-
-          const counts = { ...rest, [data.id]: temp };
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
+        const tempVal = likeCounts[newReply.id] ?? 0;
+        const { [newReply.id]: _o, ...restLikes } = likeCounts;
+        setLikeCounts({ ...restLikes, [data.id]: tempVal });
 
       }
       fetchReplies();


### PR DESCRIPTION
## Summary
- add a LikeContext to hold counts and liked state globally
- wrap the navigator with LikeProvider
- update HomeScreen, PostDetailScreen and ReplyDetailScreen to use the context

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot find type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683ab1ecc9608322bc4645b3b3590c4b