### PR TITLE
Fix like counts resetting

### DIFF
--- a/LikeContext.tsx
+++ b/LikeContext.tsx
@@ -23,11 +23,13 @@ export const LikeProvider = ({ children }: { children: React.ReactNode }) => {
   const [likedItems, setLikedItems] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
+    let active = true;
     const load = async () => {
       const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
       if (likeStored) {
         try {
-          setLikeCounts(JSON.parse(likeStored));
+          const parsed = JSON.parse(likeStored);
+          if (active) setLikeCounts(parsed);
         } catch (e) {
           console.error('Failed to parse cached like counts', e);
         }
@@ -36,19 +38,23 @@ export const LikeProvider = ({ children }: { children: React.ReactNode }) => {
         const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
         if (likedStored) {
           try {
-            setLikedItems(JSON.parse(likedStored));
+            const parsedLikes = JSON.parse(likedStored);
+            if (active) setLikedItems(parsedLikes);
           } catch (e) {
             console.error('Failed to parse cached likes', e);
           }
-        } else {
+        } else if (active) {
           setLikedItems({});
         }
-      } else {
+      } else if (active) {
         setLikedItems({});
 
       }
     };
     load();
+    return () => {
+      active = false;
+    };
   }, [user]);
 
   const refreshLikeCount = async (id: string, isPost: boolean) => {

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -434,7 +434,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                  <Text style={styles.replyCount}>{likeCounts[item.id] ?? item.like_count ?? 0}</Text>
                 </TouchableOpacity>
 
               </View>

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -560,7 +560,7 @@ export default function PostDetailScreen() {
                 color="red"
                 style={{ marginRight: 2 }}
               />
-              <Text style={styles.replyCount}>{likeCounts[post.id] || 0}</Text>
+              <Text style={styles.replyCount}>{likeCounts[post.id] ?? post.like_count ?? 0}</Text>
             </TouchableOpacity>
 
           </View>
@@ -626,7 +626,7 @@ export default function PostDetailScreen() {
                       color="red"
                       style={{ marginRight: 2 }}
                     />
-                    <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                    <Text style={styles.replyCount}>{likeCounts[item.id] ?? item.like_count ?? 0}</Text>
                   </TouchableOpacity>
 
                 </View>

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -613,7 +613,7 @@ export default function ReplyDetailScreen() {
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[originalPost.id] || 0}</Text>
+                  <Text style={styles.replyCount}>{likeCounts[originalPost.id] ?? originalPost.like_count ?? 0}</Text>
                 </TouchableOpacity>
 
               </View>
@@ -670,7 +670,7 @@ export default function ReplyDetailScreen() {
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[a.id] || 0}</Text>
+                  <Text style={styles.replyCount}>{likeCounts[a.id] ?? a.like_count ?? 0}</Text>
                 </TouchableOpacity>
 
               </View>
@@ -720,7 +720,7 @@ export default function ReplyDetailScreen() {
               color="red"
               style={{ marginRight: 2 }}
             />
-            <Text style={styles.replyCount}>{likeCounts[parent.id] || 0}</Text>
+            <Text style={styles.replyCount}>{likeCounts[parent.id] ?? parent.like_count ?? 0}</Text>
           </TouchableOpacity>
 
           </View>
@@ -788,7 +788,7 @@ export default function ReplyDetailScreen() {
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                  <Text style={styles.replyCount}>{likeCounts[item.id] ?? item.like_count ?? 0}</Text>
                 </TouchableOpacity>
 
               </View>


### PR DESCRIPTION
## Summary
- prefer cached like counts when rendering posts and replies
- cancel stale like loader to prevent resetting likes when switching users

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ae306fb588322aa0a5b524cd0c93c