### PR TITLE
Fix like count persistence

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -104,6 +104,21 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     await supabase.from('posts').delete().eq('id', id);
   };
 
+  const refreshLikeCount = async (id: string) => {
+    const { data } = await supabase
+      .from('posts')
+      .select('like_count')
+      .eq('id', id)
+      .single();
+    if (data) {
+      setLikeCounts(prev => {
+        const counts = { ...prev, [id]: data.like_count ?? 0 };
+        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
+        return counts;
+      });
+    }
+  };
+
   const toggleLike = async (id: string) => {
     if (!user) return;
     const liked = likedPosts[id];
@@ -127,6 +142,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       await supabase.from('likes').insert({ user_id: user.id, post_id: id });
 
     }
+    await refreshLikeCount(id);
   };
 
 


### PR DESCRIPTION
## Summary
- refresh like count from Supabase after toggling likes in `HomeScreen`

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683af9fa218c8322bc416ab1c65e9287