### PR TITLE
Fix like count persistence

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -104,6 +104,22 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     await supabase.from('posts').delete().eq('id', id);
   };
 
+  const refreshLikeCount = async (id: string) => {
+    const { count } = await supabase
+      .from('likes')
+      .select('id', { count: 'exact', head: true })
+      .eq('post_id', id);
+
+    if (typeof count === 'number') {
+      await supabase.from('posts').update({ like_count: count }).eq('id', id);
+      setLikeCounts(prev => {
+        const counts = { ...prev, [id]: count };
+        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
+        return counts;
+      });
+    }
+  };
+
   const toggleLike = async (id: string) => {
     if (!user) return;
     const liked = likedPosts[id];
@@ -127,6 +143,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       await supabase.from('likes').insert({ user_id: user.id, post_id: id });
 
     }
+    await refreshLikeCount(id);
   };
 
 

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -104,14 +104,18 @@ export default function PostDetailScreen() {
   };
 
   const refreshLikeCount = async (id: string, isPost: boolean) => {
-    const { data } = await supabase
-      .from(isPost ? 'posts' : 'replies')
-      .select('like_count')
-      .eq('id', id)
-      .single();
-    if (data) {
+    const { count } = await supabase
+      .from('likes')
+      .select('id', { count: 'exact', head: true })
+      .match(isPost ? { post_id: id } : { reply_id: id });
+
+    if (typeof count === 'number') {
+      await supabase
+        .from(isPost ? 'posts' : 'replies')
+        .update({ like_count: count })
+        .eq('id', id);
       setLikeCounts(prev => {
-        const counts = { ...prev, [id]: data.like_count ?? 0 };
+        const counts = { ...prev, [id]: count };
         AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
         return counts;
       });


### PR DESCRIPTION
## Summary
- update like refresh logic to compute counts from `likes` table
- update counts in posts and replies tables so values persist across screens

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683af9fa218c8322bc416ab1c65e9287