### PR TITLE
Fix like count merging

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -304,10 +304,13 @@ export default function PostDetailScreen() {
         .select('like_count')
         .eq('id', post.id)
         .single();
-      if (postLike) likeEntries.push([post.id, postLike.like_count ?? 0]);
-      else likeEntries.push([post.id, post.like_count ?? 0]);
+
+      const postLikeCount = postLike ? postLike.like_count ?? 0 : post.like_count ?? 0;
+      likeEntries.push([post.id, postLikeCount]);
+
       setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
+        const serverLikes = Object.fromEntries(likeEntries);
+        const counts = { ...serverLikes, ...prev };
         AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
         return counts;
       });
@@ -332,14 +335,6 @@ export default function PostDetailScreen() {
       }
 
       
-      if (postData) likeEntries.push([post.id, postData.like_count ?? 0]);
-      else likeEntries.push([post.id, post.like_count ?? 0]);
-      setLikeCounts(prev => {
-        const counts = { ...prev, ...Object.fromEntries(likeEntries) };
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-        return counts;
-      });
-
       if (user) {
         const { data: likeData } = await supabase
           .from('likes')
@@ -401,10 +396,10 @@ export default function PostDetailScreen() {
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
 
           const likeEntries = cached.map((r: any) => [r.id, r.like_count ?? 0]);
-          likeEntries.push([post.id, post.like_count ?? 0]);
+          likeEntries.push([post.id, storedLikes[post.id] ?? post.like_count ?? 0]);
           const likeCountsObj = {
-            ...storedLikes,
             ...Object.fromEntries(likeEntries),
+            ...storedLikes,
           };
           setLikeCounts(likeCountsObj);
           AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeCountsObj));


### PR DESCRIPTION
## Summary
- keep like count from previous state when refetching replies
- use stored like count when loading thread

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683b139826b48322a44fe489840e704c