### PR TITLE
Add optional image attachments to posts

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -17,6 +17,7 @@ import {
   Animated,
   TouchableWithoutFeedback,
   Dimensions,
+  Image,
 } from 'react-native';
 import {
   SafeAreaView,
@@ -29,6 +30,7 @@ import { useNavigation } from '@react-navigation/native';
 import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
 import { supabase } from '../lib/supabase';
 import { colors } from './styles/colors';
+import * as ImagePicker from 'expo-image-picker';
 
 
 function FollowingScreen() {
@@ -92,7 +94,19 @@ export default function TopTabsNavigator() {
   const [modalVisible, setModalVisible] = useState(false);
   const [postText, setPostText] = useState('');
   const [modalText, setModalText] = useState('');
+  const [modalImage, setModalImage] = useState<string | null>(null);
   const homeScreenRef = useRef<HomeScreenRef>(null);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      setModalImage(result.assets[0].uri);
+    }
+  };
 
   const handlePost = async () => {
     if (!postText.trim() || !user) return;
@@ -110,8 +124,9 @@ export default function TopTabsNavigator() {
   };
 
   const handleModalPost = async () => {
-    await homeScreenRef.current?.createPost(modalText);
+    await homeScreenRef.current?.createPost(modalText, modalImage ?? undefined);
     setModalText('');
+    setModalImage(null);
     setModalVisible(false);
   };
 
@@ -206,7 +221,13 @@ export default function TopTabsNavigator() {
                 value={modalText}
                 onChangeText={setModalText}
               />
-              <Button title="Post" onPress={handleModalPost} />
+              {modalImage && (
+                <Image source={{ uri: modalImage }} style={styles.preview} />
+              )}
+              <View style={styles.buttonRow}>
+                <Button title="Add Image" onPress={pickImage} />
+                <Button title="Post" onPress={handleModalPost} />
+              </View>
               <Button title="Cancel" onPress={() => setModalVisible(false)} />
             </View>
           </View>
@@ -251,6 +272,17 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     padding: 10,
     borderRadius: 6,
+    marginBottom: 10,
+  },
+  preview: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     marginBottom: 10,
   },
   fab: {

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -27,6 +27,7 @@ const LIKED_KEY_PREFIX = 'cached_likes_';
 type Post = {
   id: string;
   content: string;
+  image_url?: string;
   username?: string;
   user_id: string;
   created_at: string;
@@ -50,7 +51,7 @@ function timeAgo(dateString: string): string {
 }
 
 export interface HomeScreenRef {
-  createPost: (text: string) => Promise<void>;
+  createPost: (text: string, imageUri?: string) => Promise<void>;
 }
 
 interface HomeScreenProps {
@@ -153,7 +154,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { data, error } = await supabase
       .from('posts')
       .select(
-        'id, content, user_id, created_at, reply_count, like_count, profiles(username, display_name)',
+        'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, display_name)',
       )
       .order('created_at', { ascending: false });
 
@@ -191,7 +192,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     }
   };
 
-  const createPost = async (text: string) => {
+  const createPost = async (text: string, imageUri?: string) => {
     if (!text.trim()) return;
 
     if (!user) return;
@@ -199,6 +200,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const newPost: Post = {
       id: `temp-${Date.now()}`,
       content: text,
+      image_url: imageUri,
       username: profile.display_name || profile.username,
       user_id: user.id,
       created_at: new Date().toISOString(),
@@ -239,6 +241,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           content: text,
           user_id: user.id,
           username: profile.display_name || profile.username,
+          image_url: imageUri,
         },
       ])
 
@@ -452,6 +455,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                       {displayName} @{userName}
                     </Text>
                     <Text style={styles.postContent}>{item.content}</Text>
+                    {item.image_url && (
+                      <Image source={{ uri: item.image_url }} style={styles.postImage} />
+                    )}
                     <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
@@ -538,6 +544,12 @@ const styles = StyleSheet.create({
     transform: [{ translateX: -6 }],
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  postImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginTop: 8,
   },
 
 });

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -41,6 +41,7 @@ function timeAgo(dateString: string): string {
 interface Post {
   id: string;
   content: string;
+  image_url?: string;
   user_id: string;
   created_at: string;
 
@@ -59,6 +60,7 @@ interface Reply {
   parent_id: string | null;
   user_id: string;
   content: string;
+  image_url?: string;
   created_at: string;
 
   username?: string;
@@ -270,7 +272,7 @@ export default function PostDetailScreen() {
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      .select('id, post_id, parent_id, user_id, content, created_at, reply_count, like_count, username')
+      .select('id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username')
 
       .eq('post_id', post.id)
       .order('created_at', { ascending: false });
@@ -588,6 +590,9 @@ export default function PostDetailScreen() {
                   {displayName} @{userName}
                 </Text>
                 <Text style={styles.postContent}>{post.content}</Text>
+                {post.image_url && (
+                  <Image source={{ uri: post.image_url }} style={styles.postImage} />
+                )}
                 <Text style={styles.timestamp}>{timeAgo(post.created_at)}</Text>
               </View>
             </View>
@@ -654,6 +659,9 @@ export default function PostDetailScreen() {
                         {name} @{replyUserName}
                       </Text>
                       <Text style={styles.postContent}>{item.content}</Text>
+                      {item.image_url && (
+                        <Image source={{ uri: item.image_url }} style={styles.postImage} />
+                      )}
                       <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                     </View>
                   </View>
@@ -754,6 +762,13 @@ const styles = StyleSheet.create({
     transform: [{ translateX: -6 }],
     flexDirection: 'row',
     alignItems: 'center',
+  },
+
+  postImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginTop: 8,
   },
 
   input: {

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -44,6 +44,7 @@ interface Reply {
   parent_id: string | null;
   user_id: string;
   content: string;
+  image_url?: string;
   created_at: string;
   reply_count?: number;
   like_count?: number;
@@ -58,6 +59,7 @@ interface Reply {
 interface Post {
   id: string;
   content: string;
+  image_url?: string;
   user_id: string;
   created_at: string;
   reply_count?: number;
@@ -267,7 +269,7 @@ export default function ReplyDetailScreen() {
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      .select('id, post_id, parent_id, user_id, content, created_at, reply_count, like_count, username')
+      .select('id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username')
 
       .eq('post_id', parent.post_id)
       .order('created_at', { ascending: false });
@@ -816,6 +818,9 @@ export default function ReplyDetailScreen() {
                       {childName} @{childUserName}
                     </Text>
                     <Text style={styles.postContent}>{item.content}</Text>
+                    {item.image_url && (
+                      <Image source={{ uri: item.image_url }} style={styles.postImage} />
+                    )}
                     <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
@@ -925,6 +930,13 @@ const styles = StyleSheet.create({
     transform: [{ translateX: -6 }],
     flexDirection: 'row',
     alignItems: 'center',
+  },
+
+  postImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginTop: 8,
   },
 
   input: {

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -41,7 +41,9 @@ create policy "Anyone can read posts" on public.posts
 -- Add the username column only if it doesn't exist (for older setups)
 alter table public.posts add column if not exists username text;
 alter table public.posts add column if not exists reply_count integer not null default 0;
+alter table public.posts add column if not exists image_url text;
 alter table public.replies add column if not exists reply_count integer not null default 0;
+alter table public.replies add column if not exists image_url text;
 
 
 -- Create replies table referencing posts and profiles


### PR DESCRIPTION
## Summary
- allow selecting an image when creating posts
- save image URL in the database schema
- display post images in feeds and detail screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683b31f4cb708322b5c174fdd4e2fafa