### PR TITLE
Enable persistent avatars

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -190,6 +190,26 @@ export function AuthProvider({ children }) {
     }
   };
 
+  const uploadAvatar = async (uri) => {
+    if (!user) return;
+    try {
+      const response = await fetch(uri);
+      const blob = await response.blob();
+      const path = `${user.id}/${Date.now()}`;
+      const { error: uploadError } = await supabase.storage
+        .from('avatars')
+        .upload(path, blob, { upsert: true });
+      if (uploadError) throw uploadError;
+      const { publicURL } = supabase.storage
+        .from('avatars')
+        .getPublicUrl(path);
+      await supabase.from('profiles').update({ avatar_url: publicURL }).eq('id', user.id);
+      await setProfileImageUri(publicURL);
+    } catch (err) {
+      console.error('Failed to upload avatar', err);
+    }
+  };
+
   // 🔍 Fetch profile by ID
   const fetchProfile = async (userId) => {
     const { data, error } = await supabase
@@ -209,6 +229,10 @@ export function AuthProvider({ children }) {
           data.display_name || meta.display_name || data.username || meta.username,
       };
       setProfile(profileData);
+      if (profileData.avatar_url) {
+        setProfileImageUriState(profileData.avatar_url);
+        await AsyncStorage.setItem('profile_image_uri', profileData.avatar_url);
+      }
       return profileData;
     }
 
@@ -221,6 +245,7 @@ export function AuthProvider({ children }) {
     loading,
     profileImageUri,
     setProfileImageUri,
+    uploadAvatar,
     signUp,
     signIn,
     signOut,

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -36,6 +36,7 @@ type Post = {
   profiles?: {
     username: string | null;
     display_name: string | null;
+    avatar_url: string | null;
   } | null;
 };
 
@@ -154,7 +155,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { data, error } = await supabase
       .from('posts')
       .select(
-        'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, display_name)',
+        'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, display_name, avatar_url)',
       )
       .order('created_at', { ascending: false });
 
@@ -433,7 +434,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
             item.username;
           const userName = item.profiles?.username || item.username;
           const isMe = user?.id === item.user_id;
-          const avatarUri = isMe ? profileImageUri : undefined;
+          const avatarUri = isMe
+            ? profileImageUri
+            : item.profiles?.avatar_url || undefined;
           return (
             <TouchableOpacity onPress={() => navigation.navigate('PostDetail', { post: item })}>
               <View style={styles.post}>

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -52,6 +52,7 @@ interface Post {
   profiles?: {
     username: string | null;
     display_name: string | null;
+    avatar_url: string | null;
   } | null;
 }
 
@@ -70,6 +71,7 @@ interface Reply {
   profiles?: {
     username: string | null;
     display_name: string | null;
+    avatar_url: string | null;
   } | null;
 }
 
@@ -285,7 +287,7 @@ export default function PostDetailScreen() {
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      .select('id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username')
+      .select('id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, display_name, avatar_url)')
 
       .eq('post_id', post.id)
       .order('created_at', { ascending: false });
@@ -596,11 +598,16 @@ export default function PostDetailScreen() {
               </TouchableOpacity>
             )}
             <View style={styles.row}>
-              {user?.id === post.user_id && profileImageUri ? (
-                <Image source={{ uri: profileImageUri }} style={styles.avatar} />
-              ) : (
-                <View style={[styles.avatar, styles.placeholder]} />
-              )}
+            {(
+              user?.id === post.user_id ? profileImageUri : post.profiles?.avatar_url
+            ) ? (
+              <Image
+                source={{ uri: user?.id === post.user_id ? profileImageUri : post.profiles?.avatar_url }}
+                style={styles.avatar}
+              />
+            ) : (
+              <View style={[styles.avatar, styles.placeholder]} />
+            )}
               <View style={{ flex: 1 }}>
                 <Text style={styles.username}>
                   {displayName} @{userName}
@@ -644,7 +651,9 @@ export default function PostDetailScreen() {
           const name = item.profiles?.display_name || item.profiles?.username || item.username;
           const replyUserName = item.profiles?.username || item.username;
           const isMe = user?.id === item.user_id;
-          const avatarUri = isMe ? profileImageUri : undefined;
+          const avatarUri = isMe
+            ? profileImageUri
+            : item.profiles?.avatar_url || undefined;
           return (
             <TouchableOpacity
               onPress={() =>

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -16,7 +16,7 @@ import { colors } from '../styles/colors';
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
-  const { profile, profileImageUri, setProfileImageUri } = useAuth() as any;
+  const { profile, profileImageUri, uploadAvatar } = useAuth() as any;
 
 
   const pickImage = async () => {
@@ -31,7 +31,7 @@ export default function ProfileScreen() {
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      setProfileImageUri(result.assets[0].uri);
+      uploadAvatar(result.assets[0].uri);
 
     }
   };

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -54,6 +54,7 @@ interface Reply {
   profiles?: {
     username: string | null;
     display_name: string | null;
+    avatar_url: string | null;
   } | null;
 }
 
@@ -70,6 +71,7 @@ interface Post {
   profiles?: {
     username: string | null;
     display_name: string | null;
+    avatar_url: string | null;
   } | null;
 }
 
@@ -282,7 +284,7 @@ export default function ReplyDetailScreen() {
   const fetchReplies = async () => {
     const { data, error } = await supabase
       .from('replies')
-      .select('id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username')
+      .select('id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, display_name, avatar_url)')
 
       .eq('post_id', parent.post_id)
       .order('created_at', { ascending: false });
@@ -649,8 +651,20 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
                 )}
                 <View style={styles.row}>
-                  {user?.id === originalPost.user_id && profileImageUri ? (
-                    <Image source={{ uri: profileImageUri }} style={styles.avatar} />
+                  {(
+                    user?.id === originalPost.user_id
+                      ? profileImageUri
+                      : originalPost.profiles?.avatar_url
+                  ) ? (
+                    <Image
+                      source={{
+                        uri:
+                          user?.id === originalPost.user_id
+                            ? profileImageUri
+                            : originalPost.profiles?.avatar_url,
+                      }}
+                      style={styles.avatar}
+                    />
                   ) : (
                     <View style={[styles.avatar, styles.placeholder]} />
                   )}
@@ -659,6 +673,9 @@ export default function ReplyDetailScreen() {
                       {originalName} @{originalUserName}
                     </Text>
                     <Text style={styles.postContent}>{originalPost.content}</Text>
+                    {originalPost.image_url && (
+                      <Image source={{ uri: originalPost.image_url }} style={styles.postImage} />
+                    )}
                     <Text style={styles.timestamp}>{timeAgo(originalPost.created_at)}</Text>
                   </View>
                 </View>
@@ -692,7 +709,9 @@ export default function ReplyDetailScreen() {
                   a.profiles?.display_name || a.profiles?.username || a.username;
                 const ancestorUserName = a.profiles?.username || a.username;
                 const isMe = user?.id === a.user_id;
-                const avatarUri = isMe ? profileImageUri : undefined;
+                const avatarUri = isMe
+                  ? profileImageUri
+                  : a.profiles?.avatar_url || undefined;
                 return (
                 <View key={a.id} style={styles.post}>
                   <View style={styles.threadLine} pointerEvents="none" />
@@ -716,6 +735,9 @@ export default function ReplyDetailScreen() {
                         {ancestorName} @{ancestorUserName}
                       </Text>
                       <Text style={styles.postContent}>{a.content}</Text>
+                      {a.image_url && (
+                        <Image source={{ uri: a.image_url }} style={styles.postImage} />
+                      )}
                     <Text style={styles.timestamp}>{timeAgo(a.created_at)}</Text>
                   </View>
                 </View>
@@ -756,8 +778,18 @@ export default function ReplyDetailScreen() {
                 </TouchableOpacity>
               )}
               <View style={styles.row}>
-                {user?.id === parent.user_id && profileImageUri ? (
-                  <Image source={{ uri: profileImageUri }} style={styles.avatar} />
+                {(
+                  user?.id === parent.user_id ? profileImageUri : parent.profiles?.avatar_url
+                ) ? (
+                  <Image
+                    source={{
+                      uri:
+                        user?.id === parent.user_id
+                          ? profileImageUri
+                          : parent.profiles?.avatar_url,
+                    }}
+                    style={styles.avatar}
+                  />
                 ) : (
                   <View style={[styles.avatar, styles.placeholder]} />
                 )}
@@ -766,6 +798,9 @@ export default function ReplyDetailScreen() {
                     {name} @{parentUserName}
                   </Text>
                   <Text style={styles.postContent}>{parent.content}</Text>
+                  {parent.image_url && (
+                    <Image source={{ uri: parent.image_url }} style={styles.postImage} />
+                  )}
                   <Text style={styles.timestamp}>{timeAgo(parent.created_at)}</Text>
                 </View>
               </View>
@@ -803,7 +838,9 @@ export default function ReplyDetailScreen() {
           const childName = item.profiles?.display_name || item.profiles?.username || item.username;
           const childUserName = item.profiles?.username || item.username;
           const isMe = user?.id === item.user_id;
-          const avatarUri = isMe ? profileImageUri : undefined;
+          const avatarUri = isMe
+            ? profileImageUri
+            : item.profiles?.avatar_url || undefined;
           return (
             <TouchableOpacity
               onPress={() =>

--- a/sql/profiles.sql
+++ b/sql/profiles.sql
@@ -3,3 +3,7 @@ create policy "Users can insert their own profile"
   on public.profiles for insert
   with check (auth.uid() = id);
 
+-- Allow optional avatar_url column
+alter table public.profiles
+  add column if not exists avatar_url text;
+

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  avatar_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 


### PR DESCRIPTION
## Summary
- store avatar URL for profiles
- upload profile pictures to Supabase storage
- show avatars for posts and replies
- persist cached avatar on login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683b475bf87c8322aab9ea921ac35f7d