### PR TITLE
Enable persistent avatars via Supabase storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
-
-
-3. Copy your project's URL and `anon` key into `lib/supabase.js`.
-4. Install dependencies with `npm install`.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The setup also adds an `avatar_url` column on `profiles` for profile pictures.
+3. In Supabase Storage create a public bucket named `avatars` for profile pictures.
+4. Copy your project's URL and `anon` key into `lib/supabase.js`.
+5. Install dependencies with `npm install`.
 
 With the database configured you can run `npm start` to launch the Expo app.

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -16,7 +16,7 @@ import { colors } from '../styles/colors';
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
-  const { profile, profileImageUri, setProfileImageUri } = useAuth() as any;
+  const { profile, profileImageUri, uploadAvatar } = useAuth() as any;
 
 
   const pickImage = async () => {
@@ -31,8 +31,7 @@ export default function ProfileScreen() {
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      setProfileImageUri(result.assets[0].uri);
-
+      await uploadAvatar(result.assets[0].uri);
     }
   };
 

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -659,6 +659,9 @@ export default function ReplyDetailScreen() {
                       {originalName} @{originalUserName}
                     </Text>
                     <Text style={styles.postContent}>{originalPost.content}</Text>
+                    {originalPost.image_url && (
+                      <Image source={{ uri: originalPost.image_url }} style={styles.postImage} />
+                    )}
                     <Text style={styles.timestamp}>{timeAgo(originalPost.created_at)}</Text>
                   </View>
                 </View>
@@ -716,6 +719,9 @@ export default function ReplyDetailScreen() {
                         {ancestorName} @{ancestorUserName}
                       </Text>
                       <Text style={styles.postContent}>{a.content}</Text>
+                      {a.image_url && (
+                        <Image source={{ uri: a.image_url }} style={styles.postImage} />
+                      )}
                     <Text style={styles.timestamp}>{timeAgo(a.created_at)}</Text>
                   </View>
                 </View>
@@ -766,6 +772,9 @@ export default function ReplyDetailScreen() {
                     {name} @{parentUserName}
                   </Text>
                   <Text style={styles.postContent}>{parent.content}</Text>
+                  {parent.image_url && (
+                    <Image source={{ uri: parent.image_url }} style={styles.postImage} />
+                  )}
                   <Text style={styles.timestamp}>{timeAgo(parent.created_at)}</Text>
                 </View>
               </View>

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  avatar_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
@@ -44,6 +45,7 @@ alter table public.posts add column if not exists reply_count integer not null d
 alter table public.posts add column if not exists image_url text;
 alter table public.replies add column if not exists reply_count integer not null default 0;
 alter table public.replies add column if not exists image_url text;
+alter table public.profiles add column if not exists avatar_url text;
 
 
 -- Create replies table referencing posts and profiles


### PR DESCRIPTION
## Summary
- store `avatar_url` in `profiles` table
- support uploading avatars to a public `avatars` storage bucket
- persist avatar URL in the profile and cache locally
- update profile screen to upload the chosen image
- document bucket setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683b475bf87c8322aab9ea921ac35f7d