### PR TITLE
Store profile pictures on Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 1. Create a new project in Supabase.
 2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
 
+   The updated `sql/setup.sql` adds an `avatar_url` column to the `profiles` table. Re-run the script if your database is missing this column.
 
-3. Copy your project's URL and `anon` key into `lib/supabase.js`.
-4. Install dependencies with `npm install`.
+3. In the **Storage** section of Supabase create a bucket named `profile-images` and make it public. Profile pictures uploaded by users are stored here. If you use a different name, update `PROFILE_IMAGE_BUCKET` in `lib/supabase.js`.
+4. Copy your project's URL and `anon` key into `lib/supabase.js`.
+5. Install dependencies with `npm install`.
 
 With the database configured you can run `npm start` to launch the Expo app.

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -16,7 +16,7 @@ import { colors } from '../styles/colors';
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
-  const { profile, profileImageUri, setProfileImageUri } = useAuth() as any;
+  const { profile, profileImageUri, uploadProfileImage } = useAuth() as any;
 
 
   const pickImage = async () => {
@@ -31,8 +31,7 @@ export default function ProfileScreen() {
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      setProfileImageUri(result.assets[0].uri);
-
+      uploadProfileImage(result.assets[0].uri);
     }
   };
 

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -4,3 +4,7 @@ const supabaseUrl = 'https://yfiynxfsvpklremperpg.supabase.co';
 const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaXlueGZzdnBrbHJlbXBlcnBnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY4MTEzNTYsImV4cCI6MjA2MjM4NzM1Nn0.1sLJqsSwKKrUuJS6ln4UFoNCBssFlhGisZCsSt09x5o';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+// Storage bucket used for profile avatars. Make sure this bucket exists or
+// update the name to match your Supabase setup.
+export const PROFILE_IMAGE_BUCKET = 'profile-images';

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  avatar_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
@@ -15,6 +16,9 @@ create policy "Allow anyone to read profiles"
   on public.profiles for select using ( true );
 create policy "Users can update their own profile"
   on public.profiles for update using ( auth.uid() = id );
+
+-- Ensure new avatar_url column exists on older setups
+alter table public.profiles add column if not exists avatar_url text;
 
 -- Create posts table referencing profiles(id)
 create extension if not exists "uuid-ossp";


### PR DESCRIPTION
## Summary
- store profile pictures in a new `avatar_url` column
- upload chosen images to a public `profile-images` bucket
- persist uploaded picture URLs in user profiles and local storage
- update README with instructions for the new setup
- clarify bucket requirement and error handling

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'expo' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683c080592388322a61ca800c6c560b0