### PR TITLE
Store profile pictures on Supabase

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { supabase } from './lib/supabase';
+import { supabase, PROFILE_IMAGE_BUCKET } from './lib/supabase';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const AuthContext = createContext();
@@ -55,15 +55,7 @@ export function AuthProvider({ children }) {
     // Log any insertion error for easier debugging
     if (error) console.error('Failed to insert profile:', error);
 
-    const profileData = {
-      id: authUser.id,
-      username: defaultUsername,
-      display_name: defaultDisplayName,
-      email: authUser.email,
-    };
-
-    setProfile(profileData);
-    return profileData;
+    return await fetchProfile(authUser.id);
   };
 
   // 🔁 Refresh session on mount
@@ -181,6 +173,30 @@ export function AuthProvider({ children }) {
     await AsyncStorage.removeItem('profile_image_uri');
   };
 
+  const uploadProfileImage = async (uri) => {
+    if (!user || !uri) return;
+    try {
+      const res = await fetch(uri);
+      const blob = await res.blob();
+      const ext = uri.split('.').pop();
+      const path = `${user.id}/avatar.${ext}`;
+      const { error: uploadError } = await supabase.storage
+        .from(PROFILE_IMAGE_BUCKET)
+        .upload(path, blob, { upsert: true });
+      if (uploadError) throw uploadError;
+      const { publicURL } = supabase.storage
+        .from(PROFILE_IMAGE_BUCKET)
+        .getPublicUrl(path);
+      await supabase
+        .from('profiles')
+        .update({ avatar_url: publicURL })
+        .eq('id', user.id);
+      await setProfileImageUri(publicURL);
+    } catch (e) {
+      console.error('Failed to upload profile image', e);
+    }
+  };
+
   const setProfileImageUri = async (uri) => {
     setProfileImageUriState(uri);
     if (uri) {
@@ -209,6 +225,10 @@ export function AuthProvider({ children }) {
           data.display_name || meta.display_name || data.username || meta.username,
       };
       setProfile(profileData);
+      if (data.avatar_url) {
+        setProfileImageUriState(data.avatar_url);
+        await AsyncStorage.setItem('profile_image_uri', data.avatar_url);
+      }
       return profileData;
     }
 
@@ -221,6 +241,7 @@ export function AuthProvider({ children }) {
     loading,
     profileImageUri,
     setProfileImageUri,
+    uploadProfileImage,
     signUp,
     signIn,
     signOut,

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 1. Create a new project in Supabase.
 2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
 
+   The updated `sql/setup.sql` also adds policies so authenticated users can upload to the `profile-images` bucket. Re-run the script if your database is missing the `avatar_url` column or these policies.
 
-3. Copy your project's URL and `anon` key into `lib/supabase.js`.
-4. Install dependencies with `npm install`.
+3. In the **Storage** section of Supabase create a bucket named `profile-images` and make it public. Profile pictures uploaded by users are stored here.
+4. Copy your project's URL and `anon` key into `lib/supabase.js`.
+5. Install dependencies with `npm install`.
 
 With the database configured you can run `npm start` to launch the Expo app.

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -16,7 +16,7 @@ import { colors } from '../styles/colors';
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
-  const { profile, profileImageUri, setProfileImageUri } = useAuth() as any;
+  const { profile, profileImageUri, uploadProfileImage } = useAuth() as any;
 
 
   const pickImage = async () => {
@@ -31,8 +31,7 @@ export default function ProfileScreen() {
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      setProfileImageUri(result.assets[0].uri);
-
+      uploadProfileImage(result.assets[0].uri);
     }
   };
 

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -3,4 +3,6 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = 'https://yfiynxfsvpklremperpg.supabase.co';
 const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaXlueGZzdnBrbHJlbXBlcnBnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY4MTEzNTYsImV4cCI6MjA2MjM4NzM1Nn0.1sLJqsSwKKrUuJS6ln4UFoNCBssFlhGisZCsSt09x5o';
 
+export const PROFILE_IMAGE_BUCKET = 'profile-images';
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  avatar_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
@@ -15,6 +16,9 @@ create policy "Allow anyone to read profiles"
   on public.profiles for select using ( true );
 create policy "Users can update their own profile"
   on public.profiles for update using ( auth.uid() = id );
+
+-- Ensure new avatar_url column exists on older setups
+alter table public.profiles add column if not exists avatar_url text;
 
 -- Create posts table referencing profiles(id)
 create extension if not exists "uuid-ossp";
@@ -231,3 +235,21 @@ for each row execute procedure public.increment_like_count();
 
 create trigger like_delete after delete on public.likes
 for each row execute procedure public.decrement_like_count();
+
+-- Public bucket for profile pictures
+-- Allow authenticated users to upload and modify their images
+alter table storage.objects enable row level security;
+
+create policy "Authenticated can upload avatars" on storage.objects
+  for insert with check (
+    bucket_id = 'profile-images' and auth.role() = 'authenticated'
+  );
+
+create policy "Authenticated can update avatars" on storage.objects
+  for update using (
+    bucket_id = 'profile-images' and auth.role() = 'authenticated'
+  );
+
+-- Everyone can read the avatars since the bucket is public
+create policy "Anyone can read avatars" on storage.objects
+  for select using (bucket_id = 'profile-images');


### PR DESCRIPTION
## Summary
- store profile pictures in a new `avatar_url` column
- upload chosen images to a public `profile-images` bucket
- persist uploaded picture URLs in user profiles and local storage
- configure RLS policies so authenticated users can upload avatars
- update README with storage policy info and bucket constant

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683c080592388322a61ca800c6c560b0