### PR TITLE
Implement persistent profile images

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -182,11 +182,33 @@ export function AuthProvider({ children }) {
   };
 
   const setProfileImageUri = async (uri) => {
-    setProfileImageUriState(uri);
+    if (!user) return;
+
     if (uri) {
-      await AsyncStorage.setItem('profile_image_uri', uri);
+      try {
+        const response = await fetch(uri);
+        const blob = await response.blob();
+        const filePath = `profile-images/${user.id}`;
+        const { error } = await supabase.storage
+          .from('profile-images')
+          .upload(filePath, blob, { upsert: true });
+        if (error) throw error;
+        const { publicURL } = supabase.storage
+          .from('profile-images')
+          .getPublicUrl(filePath);
+        await supabase
+          .from('profiles')
+          .update({ avatar_url: publicURL })
+          .eq('id', user.id);
+        setProfileImageUriState(publicURL);
+        await AsyncStorage.setItem('profile_image_uri', publicURL);
+      } catch (e) {
+        console.error('Failed to upload profile image', e);
+      }
     } else {
+      setProfileImageUriState(null);
       await AsyncStorage.removeItem('profile_image_uri');
+      await supabase.from('profiles').update({ avatar_url: null }).eq('id', user.id);
     }
   };
 
@@ -209,6 +231,10 @@ export function AuthProvider({ children }) {
           data.display_name || meta.display_name || data.username || meta.username,
       };
       setProfile(profileData);
+      if (data.avatar_url) {
+        setProfileImageUriState(data.avatar_url);
+        await AsyncStorage.setItem('profile_image_uri', data.avatar_url);
+      }
       return profileData;
     }
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 
 1. Create a new project in Supabase.
 2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
+   - Create a storage bucket called `profile-images` and enable public access so profile pictures can be stored.
 
 
 3. Copy your project's URL and `anon` key into `lib/supabase.js`.

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  avatar_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
@@ -15,6 +16,8 @@ create policy "Allow anyone to read profiles"
   on public.profiles for select using ( true );
 create policy "Users can update their own profile"
   on public.profiles for update using ( auth.uid() = id );
+
+alter table public.profiles add column if not exists avatar_url text;
 
 -- Create posts table referencing profiles(id)
 create extension if not exists "uuid-ossp";


### PR DESCRIPTION
## Summary
- add `avatar_url` column to profiles table
- store profile images in Supabase Storage and persist URL
- fetch stored avatar on login
- document new bucket requirement in README

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: numerous missing declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683c41b63f648322be1f1ab1227bbf19