### PR TITLE
Fix profile picture uploads

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,3 +1,4 @@
+import 'react-native-url-polyfill/auto';
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './AuthContext';

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 
 1. Create a new project in Supabase.
 2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
+   - Create a storage bucket called `profile-images` and enable public access so profile pictures can be stored.
+   - After creating the bucket, run `sql/setup.sql` again to apply the storage policies that allow authenticated uploads to `profile-images`.
 
 
 3. Copy your project's URL and `anon` key into `lib/supabase.js`.

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  avatar_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
@@ -15,6 +16,8 @@ create policy "Allow anyone to read profiles"
   on public.profiles for select using ( true );
 create policy "Users can update their own profile"
   on public.profiles for update using ( auth.uid() = id );
+
+alter table public.profiles add column if not exists avatar_url text;
 
 -- Create posts table referencing profiles(id)
 create extension if not exists "uuid-ossp";
@@ -199,6 +202,15 @@ create policy "Users can delete their likes" on public.likes
 create policy "Anyone can read likes" on public.likes
   for select using (true);
 
+-- Allow authenticated users to upload profile pictures
+create policy "Users can upload avatar images"
+  on storage.objects for insert to authenticated
+  with check (bucket_id = 'profile-images');
+
+create policy "Users can update avatar images"
+  on storage.objects for update to authenticated
+  using (bucket_id = 'profile-images');
+
 alter table public.posts
   add column if not exists like_count integer not null default 0;
 alter table public.replies
@@ -231,3 +243,4 @@ for each row execute procedure public.increment_like_count();
 
 create trigger like_delete after delete on public.likes
 for each row execute procedure public.decrement_like_count();
+


### PR DESCRIPTION
## Summary
- polyfill React Native `URL` support for Supabase
- save avatar image to storage with content type
- document rerunning setup script for bucket policies
- allow authenticated uploads to `profile-images` bucket

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: numerous missing declarations)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683c41b63f648322be1f1ab1227bbf19