### PR TITLE
Persist uploaded images

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -31,6 +31,7 @@ import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
 import { supabase } from '../lib/supabase';
 import { colors } from './styles/colors';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 
 
 function FollowingScreen() {
@@ -104,7 +105,9 @@ export default function TopTabsNavigator() {
       quality: 0.8,
     });
     if (!result.canceled) {
-      setModalImage(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setModalImage(`data:image/jpeg;base64,${base64}`);
     }
   };
 

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -14,6 +14,7 @@ import {
   Image,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -109,7 +110,9 @@ export default function PostDetailScreen() {
       quality: 0.8,
     });
     if (!result.canceled) {
-      setReplyImage(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setReplyImage(`data:image/jpeg;base64,${base64}`);
     }
   };
 

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import { useNavigation } from '@react-navigation/native';
 
 import { useAuth } from '../../AuthContext';
@@ -31,7 +32,9 @@ export default function ProfileScreen() {
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      setProfileImageUri(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setProfileImageUri(`data:image/jpeg;base64,${base64}`);
 
     }
   };

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -14,6 +14,7 @@ import {
   Image,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -217,7 +218,9 @@ export default function ReplyDetailScreen() {
       quality: 0.8,
     });
     if (!result.canceled) {
-      setReplyImage(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setReplyImage(`data:image/jpeg;base64,${base64}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- encode selected images as base64 when picking them
- cache images via AsyncStorage by storing base64 URLs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683c61bd41e08322987a78aa261ee853