### PR TITLE
Add profile image storage

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -188,6 +188,10 @@ export function AuthProvider({ children }) {
     } else {
       await AsyncStorage.removeItem('profile_image_uri');
     }
+
+    if (user) {
+      await supabase.from('profiles').update({ image_url: uri }).eq('id', user.id);
+    }
   };
 
   // 🔍 Fetch profile by ID
@@ -209,6 +213,7 @@ export function AuthProvider({ children }) {
           data.display_name || meta.display_name || data.username || meta.username,
       };
       setProfile(profileData);
+      setProfileImageUri(data.image_url || null);
       return profileData;
     }
 

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -34,7 +34,7 @@ export default function ProfileScreen() {
     if (!result.canceled && result.assets && result.assets.length > 0) {
       const uri = result.assets[0].uri;
       const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
-      setProfileImageUri(`data:image/jpeg;base64,${base64}`);
+      await setProfileImageUri(`data:image/jpeg;base64,${base64}`);
 
     }
   };

--- a/sql/profiles.sql
+++ b/sql/profiles.sql
@@ -3,3 +3,6 @@ create policy "Users can insert their own profile"
   on public.profiles for insert
   with check (auth.uid() = id);
 
+-- Ensure profiles table has image_url column for avatars
+alter table public.profiles add column if not exists image_url text;
+

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,6 +6,7 @@ create table if not exists public.profiles (
   id uuid references auth.users(id) primary key,
   username text unique,
   display_name text,
+  image_url text,
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
@@ -39,6 +40,7 @@ create policy "Anyone can read posts" on public.posts
   for select using (true);
 
 -- Add the username column only if it doesn't exist (for older setups)
+alter table public.profiles add column if not exists image_url text;
 alter table public.posts add column if not exists username text;
 alter table public.posts add column if not exists reply_count integer not null default 0;
 alter table public.posts add column if not exists image_url text;


### PR DESCRIPTION
## Summary
- allow `profiles` to store `image_url`
- update `setProfileImageUri` to persist to Supabase
- load avatar in `fetchProfile`
- save new profile images via `ProfileScreen`
- schema migration SQL updated

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683c66a19bb08322815a4be073c2c948