### PR TITLE
Persist profile image when fetching profile

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -238,6 +238,14 @@ export function AuthProvider({ children }) {
           data.display_name || meta.display_name || data.username || meta.username,
       };
       setProfile(profileData);
+      // Restore the profile image from Supabase (do not update the DB again)
+      if (data.image_url) {
+        setProfileImageUriState(data.image_url);
+        AsyncStorage.setItem('profile_image_uri', data.image_url);
+      } else {
+        setProfileImageUriState(null);
+        AsyncStorage.removeItem('profile_image_uri');
+      }
       if (data.banner_url) {
         setBannerImageUriState(data.banner_url);
         AsyncStorage.setItem('banner_image_uri', data.banner_url);


### PR DESCRIPTION
## Summary
- ensure profile image info is saved when fetching a profile
- add note about not updating the DB when restoring

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683d4965c4248322ba08529bee147894