### PR TITLE
Enable profile viewing for other users

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
   TouchableOpacity,
   Image,
+  Dimensions,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -22,6 +23,8 @@ const STORAGE_KEY = 'cached_posts';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
 const LIKE_COUNT_KEY = 'cached_like_counts';
 const LIKED_KEY_PREFIX = 'cached_likes_';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
 
 
 type Post = {
@@ -68,6 +71,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
   const [likeCounts, setLikeCounts] = useState<{ [key: string]: number }>({});
   const [likedPosts, setLikedPosts] = useState<{ [key: string]: boolean }>({});
+  const topPadding = hideInput ? SCREEN_HEIGHT * 0.2 : 0;
 
 
 
@@ -426,6 +430,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       )}
       
       <FlatList
+        contentContainerStyle={{ paddingTop: topPadding }}
         data={posts}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => {

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Image, Button, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, Image, Button, Dimensions, ActivityIndicator } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
@@ -17,20 +17,43 @@ export default function UserProfileScreen() {
   const route = useRoute<any>();
   const { userId } = route.params as { userId: string };
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
     const fetchProfile = async () => {
+      setLoading(true);
+      setNotFound(false);
       const { data } = await supabase
         .from('profiles')
         .select('id, username, display_name, image_url, banner_url')
         .eq('id', userId)
         .single();
-      if (data) setProfile(data as Profile);
+      if (data) {
+        setProfile(data as Profile);
+      } else {
+        setNotFound(true);
+      }
+      setLoading(false);
     };
     fetchProfile();
   }, [userId]);
 
-  if (!profile) return null;
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <ActivityIndicator color="white" />
+      </View>
+    );
+  }
+
+  if (notFound || !profile) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <Text style={{ color: 'white' }}>Profile not found.</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -86,4 +109,5 @@ const styles = StyleSheet.create({
   textContainer: { marginLeft: 15 },
   username: { color: 'white', fontSize: 24, fontWeight: 'bold' },
   name: { color: 'white', fontSize: 20, marginTop: 4 },
+  center: { justifyContent: 'center', alignItems: 'center' },
 });


### PR DESCRIPTION
## Summary
- improve `UserProfileScreen` with loading and error states
- add top padding to `HomeScreen` feed so posts appear below the tab bar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683d96e5eaec8322a00a03d0ccd15438