### PR TITLE
Add banner display for visited profiles

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -37,6 +37,7 @@ type Post = {
     username: string | null;
     display_name: string | null;
     image_url?: string | null;
+    banner_url?: string | null;
   } | null;
 };
 
@@ -155,7 +156,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { data, error } = await supabase
       .from('posts')
       .select(
-        'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, display_name, image_url)',
+        'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, display_name, image_url, banner_url)',
       )
       .order('created_at', { ascending: false });
 
@@ -436,6 +437,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           const userName = item.profiles?.username || item.username;
           const isMe = user?.id === item.user_id;
           const avatarUri = isMe ? profileImageUri : item.profiles?.image_url || undefined;
+          const bannerUrl = isMe ? undefined : item.profiles?.banner_url || undefined;
 
           return (
             <TouchableOpacity onPress={() => navigation.navigate('PostDetail', { post: item })}>
@@ -453,7 +455,13 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: item.user_id, avatarUrl: avatarUri })
+                        : navigation.navigate('UserProfile', {
+                            userId: item.user_id,
+                            avatarUrl: avatarUri,
+                            bannerUrl,
+                            displayName,
+                            userName,
+                          })
                     }
                   >
                     {avatarUri ? (

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -54,6 +54,7 @@ interface Post {
     username: string | null;
     display_name: string | null;
     image_url?: string | null;
+    banner_url?: string | null;
   } | null;
 }
 
@@ -73,6 +74,7 @@ interface Reply {
     username: string | null;
     display_name: string | null;
     image_url?: string | null;
+    banner_url?: string | null;
   } | null;
 }
 
@@ -291,7 +293,7 @@ export default function PostDetailScreen() {
     const { data, error } = await supabase
       .from('replies')
       .select(
-        'id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, display_name, image_url)'
+        'id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, display_name, image_url, banner_url)'
       )
 
 
@@ -612,7 +614,13 @@ export default function PostDetailScreen() {
                 onPress={() =>
                   user?.id === post.user_id
                     ? navigation.navigate('Profile')
-                    : navigation.navigate('UserProfile', { userId: post.user_id, avatarUrl: post.profiles?.image_url })
+                    : navigation.navigate('UserProfile', {
+                        userId: post.user_id,
+                        avatarUrl: post.profiles?.image_url,
+                        bannerUrl: post.profiles?.banner_url,
+                        displayName,
+                        userName,
+                      })
                 }
               >
                 {user?.id === post.user_id && profileImageUri ? (
@@ -691,7 +699,13 @@ export default function PostDetailScreen() {
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: item.user_id, avatarUrl: avatarUri })
+                        : navigation.navigate('UserProfile', {
+                            userId: item.user_id,
+                            avatarUrl: avatarUri,
+                            bannerUrl: item.profiles?.banner_url,
+                            displayName: name,
+                            userName: replyUserName,
+                          })
                     }
                   >
                     {avatarUri ? (

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -56,6 +56,7 @@ interface Reply {
     username: string | null;
     display_name: string | null;
     image_url?: string | null;
+    banner_url?: string | null;
   } | null;
 }
 
@@ -73,6 +74,7 @@ interface Post {
     username: string | null;
     display_name: string | null;
     image_url?: string | null;
+    banner_url?: string | null;
   } | null;
 }
 
@@ -288,7 +290,7 @@ export default function ReplyDetailScreen() {
     const { data, error } = await supabase
       .from('replies')
       .select(
-        'id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, display_name, image_url)'
+        'id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, display_name, image_url, banner_url)'
       )
 
 
@@ -665,7 +667,13 @@ export default function ReplyDetailScreen() {
                     onPress={() =>
                       user?.id === originalPost.user_id
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: originalPost.user_id, avatarUrl: originalPost.profiles?.image_url })
+                        : navigation.navigate('UserProfile', {
+                            userId: originalPost.user_id,
+                            avatarUrl: originalPost.profiles?.image_url,
+                            bannerUrl: originalPost.profiles?.banner_url,
+                            displayName: originalName,
+                            userName: originalUserName,
+                          })
                     }
                   >
                     {user?.id === originalPost.user_id && profileImageUri ? (
@@ -735,7 +743,13 @@ export default function ReplyDetailScreen() {
                       onPress={() =>
                         isMe
                           ? navigation.navigate('Profile')
-                          : navigation.navigate('UserProfile', { userId: a.user_id, avatarUrl: avatarUri })
+                          : navigation.navigate('UserProfile', {
+                              userId: a.user_id,
+                              avatarUrl: avatarUri,
+                              bannerUrl: a.profiles?.banner_url,
+                              displayName: ancestorName,
+                              userName: ancestorUserName,
+                            })
                       }
                     >
                       {avatarUri ? (
@@ -797,7 +811,13 @@ export default function ReplyDetailScreen() {
                   onPress={() =>
                     user?.id === parent.user_id
                       ? navigation.navigate('Profile')
-                      : navigation.navigate('UserProfile', { userId: parent.user_id, avatarUrl: parent.profiles?.image_url })
+                      : navigation.navigate('UserProfile', {
+                          userId: parent.user_id,
+                          avatarUrl: parent.profiles?.image_url,
+                          bannerUrl: parent.profiles?.banner_url,
+                          displayName: name,
+                          userName: parentUserName,
+                        })
                   }
                 >
                   {user?.id === parent.user_id && profileImageUri ? (
@@ -878,7 +898,13 @@ export default function ReplyDetailScreen() {
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: item.user_id, avatarUrl: avatarUri })
+                        : navigation.navigate('UserProfile', {
+                            userId: item.user_id,
+                            avatarUrl: avatarUri,
+                            bannerUrl: item.profiles?.banner_url,
+                            displayName: childName,
+                            userName: childUserName,
+                          })
                     }
                   >
                     {avatarUri ? (

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -15,13 +15,26 @@ interface Profile {
 export default function UserProfileScreen() {
   const navigation = useNavigation<any>();
   const route = useRoute<any>();
-  const { userId, avatarUrl } = route.params as {
+  const {
+    userId,
+    avatarUrl,
+    bannerUrl: initialBannerUrl,
+    displayName: initialDisplayName,
+    userName: initialUsername,
+  } = route.params as {
     userId: string;
     avatarUrl?: string | null;
+    bannerUrl?: string | null;
+    displayName?: string | null;
+    userName?: string | null;
   };
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+
+  const displayName = profile?.display_name ?? initialDisplayName ?? null;
+  const username = profile?.username ?? initialUsername ?? null;
+  const banner = profile?.banner_url ?? initialBannerUrl ?? null;
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -45,7 +58,19 @@ export default function UserProfileScreen() {
   if (loading) {
     return (
       <View style={[styles.container, styles.center]}>
-        <ActivityIndicator color="white" />
+        {banner ? (
+          <Image source={{ uri: banner }} style={styles.banner} />
+        ) : (
+          <View style={[styles.banner, styles.placeholder]} />
+        )}
+        {avatarUrl ? (
+          <Image source={{ uri: avatarUrl }} style={styles.avatar} />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        {displayName && <Text style={styles.name}>{displayName}</Text>}
+        {username && <Text style={styles.username}>@{username}</Text>}
+        <ActivityIndicator color="white" style={{ marginTop: 10 }} />
       </View>
     );
   }
@@ -53,11 +78,18 @@ export default function UserProfileScreen() {
   if (notFound || !profile) {
     return (
       <View style={[styles.container, styles.center]}>
+        {banner ? (
+          <Image source={{ uri: banner }} style={styles.banner} />
+        ) : (
+          <View style={[styles.banner, styles.placeholder]} />
+        )}
         {avatarUrl ? (
           <Image source={{ uri: avatarUrl }} style={styles.avatar} />
         ) : (
           <View style={[styles.avatar, styles.placeholder]} />
         )}
+        {displayName && <Text style={styles.name}>{displayName}</Text>}
+        {username && <Text style={styles.username}>@{username}</Text>}
         <Text style={{ color: 'white', marginTop: 10 }}>Profile not found.</Text>
         <View style={styles.backButton}>
           <Button title="Back" onPress={() => navigation.goBack()} />
@@ -69,8 +101,8 @@ export default function UserProfileScreen() {
 
   return (
     <View style={styles.container}>
-      {profile.banner_url ? (
-        <Image source={{ uri: profile.banner_url }} style={styles.banner} />
+      {banner ? (
+        <Image source={{ uri: banner }} style={styles.banner} />
       ) : (
         <View style={[styles.banner, styles.placeholder]} />
       )}
@@ -84,8 +116,8 @@ export default function UserProfileScreen() {
           <View style={[styles.avatar, styles.placeholder]} />
         )}
         <View style={styles.textContainer}>
-          <Text style={styles.username}>@{profile.username}</Text>
-          {profile.display_name && <Text style={styles.name}>{profile.display_name}</Text>}
+          {displayName && <Text style={styles.name}>{displayName}</Text>}
+          {username && <Text style={styles.username}>@{username}</Text>}
         </View>
       </View>
     </View>


### PR DESCRIPTION
## Summary
- include banner data when loading posts and replies
- pass banner info to `UserProfile` screens
- show banner while loading/not found and on final profile view

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_683dc0a893408322936627e6e399e1f4