### PR TITLE
Add name/username to visited profiles

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -453,7 +453,12 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: item.user_id, avatarUrl: avatarUri })
+                        : navigation.navigate('UserProfile', {
+                            userId: item.user_id,
+                            avatarUrl: avatarUri,
+                            displayName,
+                            userName,
+                          })
                     }
                   >
                     {avatarUri ? (

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -612,7 +612,12 @@ export default function PostDetailScreen() {
                 onPress={() =>
                   user?.id === post.user_id
                     ? navigation.navigate('Profile')
-                    : navigation.navigate('UserProfile', { userId: post.user_id, avatarUrl: post.profiles?.image_url })
+                    : navigation.navigate('UserProfile', {
+                        userId: post.user_id,
+                        avatarUrl: post.profiles?.image_url,
+                        displayName,
+                        userName,
+                      })
                 }
               >
                 {user?.id === post.user_id && profileImageUri ? (
@@ -691,7 +696,12 @@ export default function PostDetailScreen() {
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: item.user_id, avatarUrl: avatarUri })
+                        : navigation.navigate('UserProfile', {
+                            userId: item.user_id,
+                            avatarUrl: avatarUri,
+                            displayName: name,
+                            userName: replyUserName,
+                          })
                     }
                   >
                     {avatarUri ? (

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -665,7 +665,12 @@ export default function ReplyDetailScreen() {
                     onPress={() =>
                       user?.id === originalPost.user_id
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: originalPost.user_id, avatarUrl: originalPost.profiles?.image_url })
+                        : navigation.navigate('UserProfile', {
+                            userId: originalPost.user_id,
+                            avatarUrl: originalPost.profiles?.image_url,
+                            displayName: originalName,
+                            userName: originalUserName,
+                          })
                     }
                   >
                     {user?.id === originalPost.user_id && profileImageUri ? (
@@ -735,7 +740,12 @@ export default function ReplyDetailScreen() {
                       onPress={() =>
                         isMe
                           ? navigation.navigate('Profile')
-                          : navigation.navigate('UserProfile', { userId: a.user_id, avatarUrl: avatarUri })
+                          : navigation.navigate('UserProfile', {
+                              userId: a.user_id,
+                              avatarUrl: avatarUri,
+                              displayName: ancestorName,
+                              userName: ancestorUserName,
+                            })
                       }
                     >
                       {avatarUri ? (
@@ -797,7 +807,12 @@ export default function ReplyDetailScreen() {
                   onPress={() =>
                     user?.id === parent.user_id
                       ? navigation.navigate('Profile')
-                      : navigation.navigate('UserProfile', { userId: parent.user_id, avatarUrl: parent.profiles?.image_url })
+                      : navigation.navigate('UserProfile', {
+                          userId: parent.user_id,
+                          avatarUrl: parent.profiles?.image_url,
+                          displayName: name,
+                          userName: parentUserName,
+                        })
                   }
                 >
                   {user?.id === parent.user_id && profileImageUri ? (
@@ -878,7 +893,12 @@ export default function ReplyDetailScreen() {
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', { userId: item.user_id, avatarUrl: avatarUri })
+                        : navigation.navigate('UserProfile', {
+                            userId: item.user_id,
+                            avatarUrl: avatarUri,
+                            displayName: childName,
+                            userName: childUserName,
+                          })
                     }
                   >
                     {avatarUri ? (

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -15,13 +15,23 @@ interface Profile {
 export default function UserProfileScreen() {
   const navigation = useNavigation<any>();
   const route = useRoute<any>();
-  const { userId, avatarUrl } = route.params as {
+  const {
+    userId,
+    avatarUrl,
+    displayName: initialDisplayName,
+    userName: initialUsername,
+  } = route.params as {
     userId: string;
     avatarUrl?: string | null;
+    displayName?: string | null;
+    userName?: string | null;
   };
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+
+  const displayName = profile?.display_name ?? initialDisplayName ?? null;
+  const username = profile?.username ?? initialUsername ?? null;
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -45,7 +55,17 @@ export default function UserProfileScreen() {
   if (loading) {
     return (
       <View style={[styles.container, styles.center]}>
-        <ActivityIndicator color="white" />
+        {profile?.image_url || avatarUrl ? (
+          <Image
+            source={{ uri: profile?.image_url || avatarUrl! }}
+            style={styles.avatar}
+          />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        {displayName && <Text style={styles.name}>{displayName}</Text>}
+        {username && <Text style={styles.username}>@{username}</Text>}
+        <ActivityIndicator color="white" style={{ marginTop: 10 }} />
       </View>
     );
   }
@@ -53,11 +73,16 @@ export default function UserProfileScreen() {
   if (notFound || !profile) {
     return (
       <View style={[styles.container, styles.center]}>
-        {avatarUrl ? (
-          <Image source={{ uri: avatarUrl }} style={styles.avatar} />
+        {profile?.image_url || avatarUrl ? (
+          <Image
+            source={{ uri: profile?.image_url || avatarUrl! }}
+            style={styles.avatar}
+          />
         ) : (
           <View style={[styles.avatar, styles.placeholder]} />
         )}
+        {displayName && <Text style={styles.name}>{displayName}</Text>}
+        {username && <Text style={styles.username}>@{username}</Text>}
         <Text style={{ color: 'white', marginTop: 10 }}>Profile not found.</Text>
         <View style={styles.backButton}>
           <Button title="Back" onPress={() => navigation.goBack()} />
@@ -78,14 +103,17 @@ export default function UserProfileScreen() {
         <Button title="Back" onPress={() => navigation.goBack()} />
       </View>
       <View style={styles.profileRow}>
-        {profile.image_url ? (
-          <Image source={{ uri: profile.image_url }} style={styles.avatar} />
+        {profile.image_url || avatarUrl ? (
+          <Image
+            source={{ uri: profile.image_url || avatarUrl! }}
+            style={styles.avatar}
+          />
         ) : (
           <View style={[styles.avatar, styles.placeholder]} />
         )}
         <View style={styles.textContainer}>
-          <Text style={styles.username}>@{profile.username}</Text>
-          {profile.display_name && <Text style={styles.name}>{profile.display_name}</Text>}
+          {displayName && <Text style={styles.name}>{displayName}</Text>}
+          {username && <Text style={styles.username}>@{username}</Text>}
         </View>
       </View>
     </View>


### PR DESCRIPTION
## Summary
- display passed profile info while loading or if not found
- show user's name and username on visited profile screen
- pass displayName/userName when navigating to UserProfile screen
- load avatar on visited profile screen even before DB fetch completes

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails to run TypeScript compiler due to missing modules)*


------
https://chatgpt.com/codex/tasks/task_e_683dc0a893408322936627e6e399e1f4