### PR TITLE
Fix reply icon alignment on home posts

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -568,7 +568,9 @@ const styles = StyleSheet.create({
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },


### PR DESCRIPTION
## Summary
- keep reply bubble lined up with post content on HomeScreen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683eeff1bffc8322b99de4d331c39a5c