### PR TITLE
Fix reply icon alignment on home posts

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -487,14 +487,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {displayName} @{userName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {displayName} @{userName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{item.content}</Text>
                     {item.image_url && (
                       <Image source={{ uri: item.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -547,6 +551,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginBottom: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -565,10 +571,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },


### PR DESCRIPTION
## Summary
- keep reply bubble lined up with post content on HomeScreen
- extend post card padding so icons don’t overlap content

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683eeff1bffc8322b99de4d331c39a5c