### PR TITLE
Fix reply icon alignment on home posts

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -487,14 +487,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {displayName} @{userName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {displayName} @{userName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{item.content}</Text>
                     {item.image_url && (
                       <Image source={{ uri: item.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -547,6 +551,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginBottom: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -565,10 +571,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -633,14 +633,18 @@ export default function PostDetailScreen() {
               </TouchableOpacity>
 
               <View style={{ flex: 1 }}>
-                <Text style={styles.username}>
-                  {displayName} @{userName}
-                </Text>
+                <View style={styles.headerRow}>
+                  <Text style={styles.username}>
+                    {displayName} @{userName}
+                  </Text>
+                  <Text style={[styles.timestamp, styles.timestampMargin]}>
+                    {timeAgo(post.created_at)}
+                  </Text>
+                </View>
                 <Text style={styles.postContent}>{post.content}</Text>
                 {post.image_url && (
                   <Image source={{ uri: post.image_url }} style={styles.postImage} />
                 )}
-                <Text style={styles.timestamp}>{timeAgo(post.created_at)}</Text>
               </View>
             </View>
             <View style={styles.replyCountContainer}>
@@ -718,16 +722,20 @@ export default function PostDetailScreen() {
                     )}
                   </TouchableOpacity>
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {name} @{replyUserName}
-                    </Text>
-
-                      <Text style={styles.postContent}>{item.content}</Text>
-                      {item.image_url && (
-                        <Image source={{ uri: item.image_url }} style={styles.postImage} />
-                      )}
-                      <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {name} @{replyUserName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
                     </View>
+
+                    <Text style={styles.postContent}>{item.content}</Text>
+                    {item.image_url && (
+                      <Image source={{ uri: item.image_url }} style={styles.postImage} />
+                    )}
+                  </View>
                   </View>
                   <View style={styles.replyCountContainer}>
                     <Ionicons
@@ -790,6 +798,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginBottom: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -808,6 +818,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginTop: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -817,10 +829,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -652,7 +652,7 @@ export default function ReplyDetailScreen() {
         ListHeaderComponent={() => (
           <>
               {originalPost && (
-                <View style={[styles.post, styles.highlightPost]}>
+                <View style={[styles.post, styles.highlightPost, styles.longReply]}>
                   <View style={styles.threadLine} pointerEvents="none" />
                   {user?.id === originalPost.user_id && (
                     <TouchableOpacity
@@ -686,14 +686,18 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {originalName} @{originalUserName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {originalName} @{originalUserName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(originalPost.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{originalPost.content}</Text>
                     {originalPost.image_url && (
                       <Image source={{ uri: originalPost.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(originalPost.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -729,7 +733,7 @@ export default function ReplyDetailScreen() {
                 const avatarUri = isMe ? profileImageUri : a.profiles?.image_url || undefined;
 
                 return (
-                <View key={a.id} style={styles.post}>
+                <View key={a.id} style={[styles.post, styles.longReply]}>
                   <View style={styles.threadLine} pointerEvents="none" />
 
                   {isMe && (
@@ -763,14 +767,18 @@ export default function ReplyDetailScreen() {
                     </TouchableOpacity>
 
                     <View style={{ flex: 1 }}>
+                    <View style={styles.headerRow}>
                       <Text style={styles.username}>
                         {ancestorName} @{ancestorUserName}
                       </Text>
-                      <Text style={styles.postContent}>{a.content}</Text>
-                      {a.image_url && (
-                        <Image source={{ uri: a.image_url }} style={styles.postImage} />
-                      )}
-                    <Text style={styles.timestamp}>{timeAgo(a.created_at)}</Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(a.created_at)}
+                      </Text>
+                    </View>
+                    <Text style={styles.postContent}>{a.content}</Text>
+                    {a.image_url && (
+                      <Image source={{ uri: a.image_url }} style={styles.postImage} />
+                    )}
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -800,7 +808,7 @@ export default function ReplyDetailScreen() {
             );
           })}
 
-            <View style={styles.post}>
+            <View style={[styles.post, styles.longReply]}>
               {user?.id === parent.user_id && (
                 <TouchableOpacity
                   onPress={() => confirmDeleteReply(parent.id)}
@@ -832,14 +840,18 @@ export default function ReplyDetailScreen() {
                 </TouchableOpacity>
 
                 <View style={{ flex: 1 }}>
-                  <Text style={styles.username}>
-                    {name} @{parentUserName}
-                  </Text>
+                  <View style={styles.headerRow}>
+                    <Text style={styles.username}>
+                      {name} @{parentUserName}
+                    </Text>
+                    <Text style={[styles.timestamp, styles.timestampMargin]}>
+                      {timeAgo(parent.created_at)}
+                    </Text>
+                  </View>
                   <Text style={styles.postContent}>{parent.content}</Text>
                   {parent.image_url && (
                     <Image source={{ uri: parent.image_url }} style={styles.postImage} />
                   )}
-                  <Text style={styles.timestamp}>{timeAgo(parent.created_at)}</Text>
                 </View>
               </View>
           <View style={styles.replyCountContainer}>
@@ -888,7 +900,7 @@ export default function ReplyDetailScreen() {
                 })
               }
             >
-              <View style={styles.reply}>
+              <View style={[styles.reply, styles.longReply]}>
                 {isMe && (
                   <TouchableOpacity
                     onPress={() => confirmDeleteReply(item.id)}
@@ -920,14 +932,18 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {childName} @{childUserName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {childName} @{childUserName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{item.content}</Text>
                     {item.image_url && (
                       <Image source={{ uri: item.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -1010,6 +1026,10 @@ const styles = StyleSheet.create({
 
     position: 'relative',
   },
+  longReply: {
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
+  },
   threadLine: {
     position: 'absolute',
     left: 26,
@@ -1027,10 +1047,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },


### PR DESCRIPTION
## Summary
- keep reply bubble lined up with post content on HomeScreen
- add extra padding to original post and thread replies so icons won't overlap

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_683eeff1bffc8322b99de4d331c39a5c