### PR TITLE
Add follow counts to profile view

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql` **and** `sql/likes.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql` **and** `sql/follows.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf.
 
 
 3. Copy your project's URL and `anon` key into `lib/supabase.js`.

--- a/app/components/FollowButton.tsx
+++ b/app/components/FollowButton.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from 'react-native';
+import { supabase } from '../../lib/supabase';
+import { useAuth } from '../../AuthContext';
+
+interface FollowButtonProps {
+  targetUserId: string;
+}
+
+export default function FollowButton({ targetUserId }: FollowButtonProps) {
+  const { user } = useAuth() as any;
+  const [following, setFollowing] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    let isMounted = true;
+    const checkFollow = async () => {
+      const { data, error } = await supabase
+        .from('follows')
+        .select('id')
+        .match({ follower_id: user.id, following_id: targetUserId })
+        .single();
+      if (isMounted) {
+        if (error && error.code !== 'PGRST116') {
+          console.error('Failed to fetch follow state', error);
+        }
+        setFollowing(!!data);
+      }
+    };
+    checkFollow();
+    return () => {
+      isMounted = false;
+    };
+  }, [user, targetUserId]);
+
+  const toggleFollow = async () => {
+    if (!user) return;
+    if (following) {
+      const { error } = await supabase
+        .from('follows')
+        .delete()
+        .match({ follower_id: user.id, following_id: targetUserId });
+      if (!error) setFollowing(false);
+      else console.error('Failed to unfollow', error);
+    } else {
+      const { error } = await supabase
+        .from('follows')
+        .insert({ follower_id: user.id, following_id: targetUserId });
+      if (!error) setFollowing(true);
+      else console.error('Failed to follow', error);
+    }
+  };
+
+  if (following === null) {
+    // Avoid flashing incorrect state until we know if a follow exists
+    return null;
+  }
+
+  return (
+    <Button title={following ? 'Unfollow' : 'Follow'} onPress={toggleFollow} />
+  );
+}

--- a/app/hooks/useFollowCounts.ts
+++ b/app/hooks/useFollowCounts.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabase';
+
+export function useFollowCounts(userId: string | null) {
+  const [followers, setFollowers] = useState<number | null>(null);
+  const [following, setFollowing] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!userId) {
+      setFollowers(null);
+      setFollowing(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchCounts = async () => {
+      const followersPromise = supabase
+        .from('follows')
+        .select('id', { count: 'exact', head: true })
+        .eq('following_id', userId);
+
+      const followingPromise = supabase
+        .from('follows')
+        .select('id', { count: 'exact', head: true })
+        .eq('follower_id', userId);
+
+      const [followersRes, followingRes] = await Promise.all([
+        followersPromise,
+        followingPromise,
+      ]);
+
+      if (!isMounted) return;
+
+      if (!followersRes.error) {
+        setFollowers(followersRes.count ?? 0);
+      } else {
+        console.error('Failed to fetch followers', followersRes.error);
+      }
+
+      if (!followingRes.error) {
+        setFollowing(followingRes.count ?? 0);
+      } else {
+        console.error('Failed to fetch following', followingRes.error);
+      }
+    };
+
+    fetchCounts();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId]);
+
+  return { followers, following };
+}

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -487,14 +487,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {displayName} @{userName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {displayName} @{userName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{item.content}</Text>
                     {item.image_url && (
                       <Image source={{ uri: item.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -547,6 +551,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginBottom: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -565,10 +571,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -633,14 +633,18 @@ export default function PostDetailScreen() {
               </TouchableOpacity>
 
               <View style={{ flex: 1 }}>
-                <Text style={styles.username}>
-                  {displayName} @{userName}
-                </Text>
+                <View style={styles.headerRow}>
+                  <Text style={styles.username}>
+                    {displayName} @{userName}
+                  </Text>
+                  <Text style={[styles.timestamp, styles.timestampMargin]}>
+                    {timeAgo(post.created_at)}
+                  </Text>
+                </View>
                 <Text style={styles.postContent}>{post.content}</Text>
                 {post.image_url && (
                   <Image source={{ uri: post.image_url }} style={styles.postImage} />
                 )}
-                <Text style={styles.timestamp}>{timeAgo(post.created_at)}</Text>
               </View>
             </View>
             <View style={styles.replyCountContainer}>
@@ -718,16 +722,20 @@ export default function PostDetailScreen() {
                     )}
                   </TouchableOpacity>
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {name} @{replyUserName}
-                    </Text>
-
-                      <Text style={styles.postContent}>{item.content}</Text>
-                      {item.image_url && (
-                        <Image source={{ uri: item.image_url }} style={styles.postImage} />
-                      )}
-                      <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {name} @{replyUserName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
                     </View>
+
+                    <Text style={styles.postContent}>{item.content}</Text>
+                    {item.image_url && (
+                      <Image source={{ uri: item.image_url }} style={styles.postImage} />
+                    )}
+                  </View>
                   </View>
                   <View style={styles.replyCountContainer}>
                     <Ionicons
@@ -790,6 +798,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginBottom: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -808,6 +818,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff10',
     borderRadius: 0,
     padding: 10,
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
     marginTop: 0,
     borderBottomColor: 'gray',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -817,10 +829,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -652,7 +652,7 @@ export default function ReplyDetailScreen() {
         ListHeaderComponent={() => (
           <>
               {originalPost && (
-                <View style={[styles.post, styles.highlightPost]}>
+                <View style={[styles.post, styles.highlightPost, styles.longReply]}>
                   <View style={styles.threadLine} pointerEvents="none" />
                   {user?.id === originalPost.user_id && (
                     <TouchableOpacity
@@ -686,14 +686,18 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {originalName} @{originalUserName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {originalName} @{originalUserName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(originalPost.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{originalPost.content}</Text>
                     {originalPost.image_url && (
                       <Image source={{ uri: originalPost.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(originalPost.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -729,7 +733,7 @@ export default function ReplyDetailScreen() {
                 const avatarUri = isMe ? profileImageUri : a.profiles?.image_url || undefined;
 
                 return (
-                <View key={a.id} style={styles.post}>
+                <View key={a.id} style={[styles.post, styles.longReply]}>
                   <View style={styles.threadLine} pointerEvents="none" />
 
                   {isMe && (
@@ -763,14 +767,18 @@ export default function ReplyDetailScreen() {
                     </TouchableOpacity>
 
                     <View style={{ flex: 1 }}>
+                    <View style={styles.headerRow}>
                       <Text style={styles.username}>
                         {ancestorName} @{ancestorUserName}
                       </Text>
-                      <Text style={styles.postContent}>{a.content}</Text>
-                      {a.image_url && (
-                        <Image source={{ uri: a.image_url }} style={styles.postImage} />
-                      )}
-                    <Text style={styles.timestamp}>{timeAgo(a.created_at)}</Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(a.created_at)}
+                      </Text>
+                    </View>
+                    <Text style={styles.postContent}>{a.content}</Text>
+                    {a.image_url && (
+                      <Image source={{ uri: a.image_url }} style={styles.postImage} />
+                    )}
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -800,7 +808,7 @@ export default function ReplyDetailScreen() {
             );
           })}
 
-            <View style={styles.post}>
+            <View style={[styles.post, styles.longReply]}>
               {user?.id === parent.user_id && (
                 <TouchableOpacity
                   onPress={() => confirmDeleteReply(parent.id)}
@@ -832,14 +840,18 @@ export default function ReplyDetailScreen() {
                 </TouchableOpacity>
 
                 <View style={{ flex: 1 }}>
-                  <Text style={styles.username}>
-                    {name} @{parentUserName}
-                  </Text>
+                  <View style={styles.headerRow}>
+                    <Text style={styles.username}>
+                      {name} @{parentUserName}
+                    </Text>
+                    <Text style={[styles.timestamp, styles.timestampMargin]}>
+                      {timeAgo(parent.created_at)}
+                    </Text>
+                  </View>
                   <Text style={styles.postContent}>{parent.content}</Text>
                   {parent.image_url && (
                     <Image source={{ uri: parent.image_url }} style={styles.postImage} />
                   )}
-                  <Text style={styles.timestamp}>{timeAgo(parent.created_at)}</Text>
                 </View>
               </View>
           <View style={styles.replyCountContainer}>
@@ -888,7 +900,7 @@ export default function ReplyDetailScreen() {
                 })
               }
             >
-              <View style={styles.reply}>
+              <View style={[styles.reply, styles.longReply]}>
                 {isMe && (
                   <TouchableOpacity
                     onPress={() => confirmDeleteReply(item.id)}
@@ -920,14 +932,18 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
 
                   <View style={{ flex: 1 }}>
-                    <Text style={styles.username}>
-                      {childName} @{childUserName}
-                    </Text>
+                    <View style={styles.headerRow}>
+                      <Text style={styles.username}>
+                        {childName} @{childUserName}
+                      </Text>
+                      <Text style={[styles.timestamp, styles.timestampMargin]}>
+                        {timeAgo(item.created_at)}
+                      </Text>
+                    </View>
                     <Text style={styles.postContent}>{item.content}</Text>
                     {item.image_url && (
                       <Image source={{ uri: item.image_url }} style={styles.postImage} />
                     )}
-                    <Text style={styles.timestamp}>{timeAgo(item.created_at)}</Text>
                   </View>
                 </View>
                 <View style={styles.replyCountContainer}>
@@ -1010,6 +1026,10 @@ const styles = StyleSheet.create({
 
     position: 'relative',
   },
+  longReply: {
+    // add extra space at the bottom so action icons don't overlap content
+    paddingBottom: 30,
+  },
   threadLine: {
     position: 'absolute',
     left: 26,
@@ -1027,10 +1047,14 @@ const styles = StyleSheet.create({
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
     position: 'absolute',
     bottom: 6,
-    left: 10,
+    // Align with the left edge of the post content (text/image)
+    // Avatar width (32) + margin (8) + container padding (10)
+    left: 50,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Image, Button, Dimensions, ActivityIndicator } 
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
+import { useFollowCounts } from '../hooks/useFollowCounts';
 
 interface Profile {
   id: string;
@@ -36,6 +37,7 @@ export default function UserProfileScreen() {
 
   const displayName = profile?.display_name ?? initialDisplayName ?? null;
   const username = profile?.username ?? initialUsername ?? null;
+  const { followers, following } = useFollowCounts(userId);
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -144,6 +146,10 @@ export default function UserProfileScreen() {
           {username && <Text style={styles.username}>@{username}</Text>}
         </View>
       </View>
+      <View style={styles.statsRow}>
+        <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+        <Text style={styles.statsText}>{following ?? 0} Following</Text>
+      </View>
     </View>
   );
 }
@@ -178,4 +184,6 @@ const styles = StyleSheet.create({
   username: { color: 'white', fontSize: 24, fontWeight: 'bold' },
   name: { color: 'white', fontSize: 20, marginTop: 4 },
   center: { justifyContent: 'center', alignItems: 'center' },
+  statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
+  statsText: { color: 'white', marginRight: 15 },
 });

--- a/sql/follows.sql
+++ b/sql/follows.sql
@@ -1,0 +1,23 @@
+-- Setup follows table for following relationships
+
+-- Ensure pgcrypto is available for gen_random_uuid
+create extension if not exists pgcrypto;
+
+create table if not exists public.follows (
+    id uuid primary key default gen_random_uuid(),
+    follower_id uuid not null references auth.users(id),
+    following_id uuid not null references auth.users(id),
+    created_at timestamptz not null default now(),
+    unique (follower_id, following_id)
+);
+
+alter table public.follows enable row level security;
+
+create policy "Users can follow" on public.follows
+  for insert with check (auth.uid() = follower_id);
+
+create policy "Users can unfollow" on public.follows
+  for delete using (auth.uid() = follower_id);
+
+create policy "Anyone can read follows" on public.follows
+  for select using (true);


### PR DESCRIPTION
## Summary
- create `useFollowCounts` hook to fetch follower/following totals
- show followers and following numbers on `UserProfileScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683eeff1bffc8322b99de4d331c39a5c