### PR TITLE
Add follow button in UserProfileScreen

### DIFF
--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -134,6 +134,15 @@ export default function UserProfileScreen() {
         )}
         {displayName && <Text style={styles.name}>{displayName}</Text>}
         {username && <Text style={styles.username}>@{username}</Text>}
+        {user && user.id !== userId && (
+          <View style={{ marginTop: 10 }}>
+            <FollowButton targetUserId={userId} onToggle={refresh} />
+          </View>
+        )}
+        <View style={styles.statsRow}>
+          <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+          <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        </View>
         <ActivityIndicator color="white" style={{ marginTop: 10 }} />
       </View>
     );
@@ -162,6 +171,15 @@ export default function UserProfileScreen() {
         )}
         {displayName && <Text style={styles.name}>{displayName}</Text>}
         {username && <Text style={styles.username}>@{username}</Text>}
+        {user && user.id !== userId && (
+          <View style={{ marginTop: 10 }}>
+            <FollowButton targetUserId={userId} onToggle={refresh} />
+          </View>
+        )}
+        <View style={styles.statsRow}>
+          <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+          <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        </View>
         <Text style={{ color: 'white', marginTop: 10 }}>Profile not found.</Text>
         <View style={styles.backButton}>
           <Button title="Back" onPress={() => navigation.goBack()} />


### PR DESCRIPTION
## Summary
- always render the follow/unfollow button when viewing a user profile

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_683ff4fa82808322b9ec7f93e3c52dbd