### PR TITLE
Add follow list navigation

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -6,6 +6,7 @@ import PostDetailScreen from './app/screens/PostDetailScreen';
 import ReplyDetailScreen from './app/screens/ReplyDetailScreen';
 import ProfileScreen from './app/screens/ProfileScreen';
 import UserProfileScreen from './app/screens/UserProfileScreen';
+import FollowListScreen from './app/screens/FollowListScreen';
 import { useAuth } from './AuthContext';
 
 const Stack = createNativeStackNavigator();
@@ -24,6 +25,7 @@ export default function Navigator() {
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="UserProfile" component={UserProfileScreen} />
+          <Stack.Screen name="FollowList" component={FollowListScreen} />
         </>
       ) : (
         <Stack.Screen name="Auth" component={AuthPage} />

--- a/app/components/FollowingList.tsx
+++ b/app/components/FollowingList.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { View, Text, Image, FlatList, StyleSheet } from 'react-native';
+import { colors } from '../styles/colors';
+
+export interface FollowingUser {
+  username: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+interface FollowingListProps {
+  users: FollowingUser[];
+}
+
+export default function FollowingList({ users }: FollowingListProps) {
+  const renderItem = ({ item }: { item: FollowingUser }) => (
+    <View style={styles.row}>
+      {item.avatar_url ? (
+        <Image source={{ uri: item.avatar_url }} style={styles.avatar} />
+      ) : (
+        <View style={[styles.avatar, styles.placeholder]} />
+      )}
+      <View>
+        {item.full_name && <Text style={styles.fullName}>{item.full_name}</Text>}
+        {item.username && (
+          <Text style={styles.username}>@{item.username}</Text>
+        )}
+      </View>
+    </View>
+  );
+
+  return (
+    <FlatList
+      data={users}
+      keyExtractor={(item, index) => item.username ?? index.toString()}
+      renderItem={renderItem}
+      contentContainerStyle={styles.container}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    marginRight: 12,
+  },
+  placeholder: {
+    backgroundColor: '#555',
+  },
+  fullName: {
+    color: colors.text,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  username: {
+    color: colors.text,
+    fontSize: 14,
+    opacity: 0.8,
+  },
+});

--- a/app/screens/FollowListScreen.tsx
+++ b/app/screens/FollowListScreen.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useRoute } from '@react-navigation/native';
+import { colors } from '../styles/colors';
+import FollowingList, { FollowingUser } from '../components/FollowingList';
+import { getFollowingProfiles } from '../../lib/getFollowingProfiles';
+import { getFollowersProfiles } from '../../lib/getFollowersProfiles';
+
+export default function FollowListScreen() {
+  const route = useRoute<any>();
+  const { userId, mode } = route.params as {
+    userId: string;
+    mode: 'followers' | 'following';
+  };
+
+  const [profiles, setProfiles] = useState<FollowingUser[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchProfiles = async () => {
+      try {
+        const data =
+          mode === 'followers'
+            ? await getFollowersProfiles(userId)
+            : await getFollowingProfiles(userId);
+        if (isMounted) setProfiles(data);
+      } catch (e) {
+        console.error('Failed to fetch follow list', e);
+      }
+    };
+    fetchProfiles();
+    return () => {
+      isMounted = false;
+    };
+  }, [userId, mode]);
+
+  return (
+    <View style={styles.container}>
+      <FollowingList users={profiles} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -93,8 +93,26 @@ export default function ProfileScreen() {
         </View>
       </View>
       <View style={styles.statsRow}>
-        <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
-        <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', {
+              userId: profile.id,
+              mode: 'followers',
+            })
+          }
+        >
+          <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', {
+              userId: profile.id,
+              mode: 'following',
+            })
+          }
+        >
+          <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        </TouchableOpacity>
       </View>
       <TouchableOpacity onPress={pickImage} style={styles.uploadLink}>
         <Text style={styles.uploadText}>Upload Profile Picture</Text>

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Image, Button, Dimensions, ActivityIndicator, FlatList } from 'react-native';
+import { View, Text, StyleSheet, Image, Button, Dimensions, ActivityIndicator, FlatList, TouchableOpacity } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
@@ -134,6 +134,33 @@ export default function UserProfileScreen() {
         )}
         {displayName && <Text style={styles.name}>{displayName}</Text>}
         {username && <Text style={styles.username}>@{username}</Text>}
+        {user && user.id !== userId && (
+          <View style={{ marginTop: 10 }}>
+            <FollowButton targetUserId={userId} onToggle={refresh} />
+          </View>
+        )}
+        <View style={styles.statsRow}>
+          <TouchableOpacity
+            onPress={() =>
+              navigation.navigate('FollowList', {
+                userId,
+                mode: 'followers',
+              })
+            }
+          >
+            <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() =>
+              navigation.navigate('FollowList', {
+                userId,
+                mode: 'following',
+              })
+            }
+          >
+            <Text style={styles.statsText}>{following ?? 0} Following</Text>
+          </TouchableOpacity>
+        </View>
         <ActivityIndicator color="white" style={{ marginTop: 10 }} />
       </View>
     );
@@ -162,6 +189,33 @@ export default function UserProfileScreen() {
         )}
         {displayName && <Text style={styles.name}>{displayName}</Text>}
         {username && <Text style={styles.username}>@{username}</Text>}
+        {user && user.id !== userId && (
+          <View style={{ marginTop: 10 }}>
+            <FollowButton targetUserId={userId} onToggle={refresh} />
+          </View>
+        )}
+        <View style={styles.statsRow}>
+          <TouchableOpacity
+            onPress={() =>
+              navigation.navigate('FollowList', {
+                userId,
+                mode: 'followers',
+              })
+            }
+          >
+            <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() =>
+              navigation.navigate('FollowList', {
+                userId,
+                mode: 'following',
+              })
+            }
+          >
+            <Text style={styles.statsText}>{following ?? 0} Following</Text>
+          </TouchableOpacity>
+        </View>
         <Text style={{ color: 'white', marginTop: 10 }}>Profile not found.</Text>
         <View style={styles.backButton}>
           <Button title="Back" onPress={() => navigation.goBack()} />
@@ -205,8 +259,26 @@ export default function UserProfileScreen() {
         )}
       </View>
       <View style={styles.statsRow}>
-        <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
-        <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', {
+              userId,
+              mode: 'followers',
+            })
+          }
+        >
+          <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', {
+              userId,
+              mode: 'following',
+            })
+          }
+        >
+          <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        </TouchableOpacity>
       </View>
 
       <Text style={styles.sectionTitle}>Following</Text>

--- a/lib/getFollowersProfiles.ts
+++ b/lib/getFollowersProfiles.ts
@@ -1,0 +1,38 @@
+import { supabase } from './supabase';
+
+export interface FollowerProfile {
+  username: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+export async function getFollowersProfiles(userId: string): Promise<FollowerProfile[]> {
+  const { data: follows, error: followsError } = await supabase
+    .from('follows')
+    .select('follower_id')
+    .eq('following_id', userId);
+
+  if (followsError) {
+    console.error('Failed to fetch followers list', followsError);
+    throw followsError;
+  }
+
+  const ids = (follows ?? []).map(f => f.follower_id);
+  if (ids.length === 0) return [];
+
+  const { data: profiles, error: profileError } = await supabase
+    .from('profiles')
+    .select('username, display_name, image_url')
+    .in('id', ids);
+
+  if (profileError) {
+    console.error('Failed to fetch profiles', profileError);
+    throw profileError;
+  }
+
+  return (profiles ?? []).map(p => ({
+    username: p.username ?? null,
+    full_name: p.display_name ?? null,
+    avatar_url: p.image_url ?? null,
+  }));
+}

--- a/lib/getFollowingProfiles.ts
+++ b/lib/getFollowingProfiles.ts
@@ -1,0 +1,40 @@
+import { supabase } from './supabase';
+
+export interface FollowingProfile {
+  username: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+export async function getFollowingProfiles(userId: string): Promise<FollowingProfile[]> {
+  // Fetch the ids this user is following
+  const { data: follows, error: followsError } = await supabase
+    .from('follows')
+    .select('following_id')
+    .eq('follower_id', userId);
+
+  if (followsError) {
+    console.error('Failed to fetch following list', followsError);
+    throw followsError;
+  }
+
+  const ids = (follows ?? []).map(f => f.following_id);
+  if (ids.length === 0) return [];
+
+  // Look up the corresponding profiles
+  const { data: profiles, error: profileError } = await supabase
+    .from('profiles')
+    .select('username, display_name, image_url')
+    .in('id', ids);
+
+  if (profileError) {
+    console.error('Failed to fetch profiles', profileError);
+    throw profileError;
+  }
+
+  return (profiles ?? []).map(p => ({
+    username: p.username ?? null,
+    full_name: p.display_name ?? null,
+    avatar_url: p.image_url ?? null,
+  }));
+}


### PR DESCRIPTION
## Summary
- allow navigation to a FollowList screen from profile counts
- add FollowListScreen for viewing followers or following
- provide fetching helpers for follower profiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683ff4fa82808322b9ec7f93e3c52dbd