### PR TITLE
Increase reply count display size

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -502,11 +502,11 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                 <View style={styles.replyCountContainer}>
                   <Ionicons
                     name="chatbubble-outline"
-                    size={12}
+                    size={18}
                     color="#66538f"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
+                  <Text style={styles.replyCountLarge}>{replyCounts[item.id] || 0}</Text>
                 </View>
                 <TouchableOpacity
                   style={styles.likeContainer}
@@ -581,6 +581,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  replyCountLarge: { fontSize: 15, color: 'gray' },
   likeContainer: {
     position: 'absolute',
     bottom: 6,


### PR DESCRIPTION
## Summary
- enlarge reply bubble icon and reply count on HomeScreen feed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68406250b1b08322a98b9c2b17ec4ef3