### PR TITLE
Add reply modal on HomeScreen

### DIFF
--- a/app/screens/FollowListScreen.tsx
+++ b/app/screens/FollowListScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, StyleSheet } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { View, StyleSheet, Button, Dimensions } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
 import { colors } from '../styles/colors';
 import FollowingList, { FollowingUser } from '../components/FollowingList';
 import { getFollowingProfiles } from '../../lib/getFollowingProfiles';
@@ -8,6 +8,7 @@ import { getFollowersProfiles } from '../../lib/getFollowersProfiles';
 
 export default function FollowListScreen() {
   const route = useRoute<any>();
+  const navigation = useNavigation<any>();
   const { userId, mode } = route.params as {
     userId: string;
     mode: 'followers' | 'following';
@@ -36,7 +37,12 @@ export default function FollowListScreen() {
 
   return (
     <View style={styles.container}>
-      <FollowingList users={profiles} />
+      <View style={styles.backButton}>
+        <Button title="Back" onPress={() => navigation.goBack()} />
+      </View>
+      <View style={styles.listContainer}>
+        <FollowingList users={profiles} />
+      </View>
     </View>
   );
 }
@@ -45,5 +51,13 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
+  },
+  backButton: {
+    alignSelf: 'flex-start',
+    marginTop: Dimensions.get('window').height * 0.1,
+    marginBottom: 20,
+  },
+  listContainer: {
+    marginTop: Dimensions.get('window').height * 0.1,
   },
 });

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -10,7 +10,12 @@ import {
   TouchableOpacity,
   Image,
   ActivityIndicator,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useCallback } from 'react';
@@ -73,6 +78,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const [likedPosts, setLikedPosts] = useState<{ [key: string]: boolean }>({});
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const [replyModalVisible, setReplyModalVisible] = useState(false);
+  const [activePostId, setActivePostId] = useState<string | null>(null);
+  const [replyText, setReplyText] = useState('');
+  const [replyImage, setReplyImage] = useState<string | null>(null);
 
 
 
@@ -151,6 +160,64 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
     }
     await refreshLikeCount(id);
+  };
+
+  const openReplyModal = (postId: string) => {
+    setActivePostId(postId);
+    setReplyText('');
+    setReplyImage(null);
+    setReplyModalVisible(true);
+  };
+
+  const pickReplyImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, {
+        encoding: 'base64',
+      });
+      setReplyImage(`data:image/jpeg;base64,${base64}`);
+    }
+  };
+
+  const handleReplySubmit = async () => {
+    if (!activePostId || (!replyText.trim() && !replyImage) || !user) {
+      setReplyModalVisible(false);
+      return;
+    }
+
+    setReplyModalVisible(false);
+
+    setReplyCounts(prev => {
+      const counts = { ...prev, [activePostId]: (prev[activePostId] || 0) + 1 };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
+
+    const { error } = await supabase.from('replies').insert({
+      post_id: activePostId,
+      parent_id: null,
+      user_id: user.id,
+      content: replyText,
+      image_url: replyImage,
+      username: profile.name || profile.username,
+    });
+
+    if (error) {
+      setReplyCounts(prev => {
+        const counts = { ...prev, [activePostId]: (prev[activePostId] || 1) - 1 };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+        return counts;
+      });
+      Alert.alert('Reply failed', error.message);
+    }
+
+    setReplyText('');
+    setReplyImage(null);
   };
 
 
@@ -499,27 +566,29 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                     )}
                   </View>
                 </View>
-                <View style={styles.replyCountContainer}>
+                <TouchableOpacity
+                  style={styles.replyCountContainer}
+                  onPress={() => openReplyModal(item.id)}
+                >
                   <Ionicons
                     name="chatbubble-outline"
-                    size={12}
+                    size={18}
                     color="#66538f"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
-                </View>
+                  <Text style={styles.replyCountLarge}>{replyCounts[item.id] || 0}</Text>
+                </TouchableOpacity>
                 <TouchableOpacity
                   style={styles.likeContainer}
                   onPress={() => toggleLike(item.id)}
                 >
                   <Ionicons
                     name={likedPosts[item.id] ? 'heart' : 'heart-outline'}
-
-                    size={12}
+                    size={18}
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                  <Text style={styles.likeCountLarge}>{likeCounts[item.id] || 0}</Text>
                 </TouchableOpacity>
 
               </View>
@@ -527,6 +596,29 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           );
         }}
       />
+      <Modal visible={replyModalVisible} animationType="slide" transparent>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.modalOverlay}
+        >
+          <View style={styles.modalContent}>
+            <TextInput
+              placeholder="Write a reply"
+              value={replyText}
+              onChangeText={setReplyText}
+              style={styles.input}
+              multiline
+            />
+            {replyImage && (
+              <Image source={{ uri: replyImage }} style={styles.preview} />
+            )}
+            <View style={styles.buttonRow}>
+              <Button title="Add Image" onPress={pickReplyImage} />
+              <Button title="Post" onPress={handleReplySubmit} />
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </View>
   );
 });
@@ -558,7 +650,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   row: { flexDirection: 'row', alignItems: 'flex-start' },
-  avatar: { width: 32, height: 32, borderRadius: 16, marginRight: 8 },
+  avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 8 },
   placeholder: { backgroundColor: '#555' },
   deleteButton: {
     position: 'absolute',
@@ -575,12 +667,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 6,
     // Align with the left edge of the post content (text/image)
-    // Avatar width (32) + margin (8) + container padding (10)
-    left: 50,
+    // Avatar width (48) + margin (8) + container padding (10)
+    left: 66,
     flexDirection: 'row',
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  replyCountLarge: { fontSize: 15, color: 'gray' },
+  likeCountLarge: { fontSize: 15, color: 'gray' },
   likeContainer: {
     position: 'absolute',
     bottom: 6,
@@ -588,6 +682,26 @@ const styles = StyleSheet.create({
     transform: [{ translateX: -6 }],
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: colors.background,
+    padding: 20,
+  },
+  preview: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
   },
   postImage: {
     width: '100%',

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -650,11 +650,11 @@ export default function PostDetailScreen() {
             <View style={styles.replyCountContainer}>
               <Ionicons
                 name="chatbubble-outline"
-                size={12}
+                size={18}
                 color="#66538f"
                 style={{ marginRight: 2 }}
               />
-              <Text style={styles.replyCount}>{replyCounts[post.id] || 0}</Text>
+              <Text style={styles.replyCountLarge}>{replyCounts[post.id] || 0}</Text>
             </View>
             <TouchableOpacity
               style={styles.likeContainer}
@@ -663,11 +663,11 @@ export default function PostDetailScreen() {
               <Ionicons
                 name={likedItems[post.id] ? 'heart' : 'heart-outline'}
 
-                size={12}
+                size={18}
                 color="red"
                 style={{ marginRight: 2 }}
               />
-              <Text style={styles.replyCount}>{likeCounts[post.id] || 0}</Text>
+              <Text style={styles.likeCountLarge}>{likeCounts[post.id] || 0}</Text>
             </TouchableOpacity>
 
           </View>
@@ -740,11 +740,11 @@ export default function PostDetailScreen() {
                   <View style={styles.replyCountContainer}>
                     <Ionicons
                       name="chatbubble-outline"
-                      size={12}
+                      size={18}
                       color="#66538f"
                       style={{ marginRight: 2 }}
                     />
-                    <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
+                    <Text style={styles.replyCountLarge}>{replyCounts[item.id] || 0}</Text>
                   </View>
                   <TouchableOpacity
                     style={styles.likeContainer}
@@ -753,11 +753,11 @@ export default function PostDetailScreen() {
                     <Ionicons
                       name={likedItems[item.id] ? 'heart' : 'heart-outline'}
 
-                      size={12}
+                      size={18}
                       color="red"
                       style={{ marginRight: 2 }}
                     />
-                    <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                    <Text style={styles.likeCountLarge}>{likeCounts[item.id] || 0}</Text>
                   </TouchableOpacity>
 
                 </View>
@@ -807,7 +807,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   row: { flexDirection: 'row', alignItems: 'flex-start' },
-  avatar: { width: 32, height: 32, borderRadius: 16, marginRight: 8 },
+  avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 8 },
   placeholder: { backgroundColor: '#555' },
   highlightPost: {
     borderColor: '#4f1fde',
@@ -835,12 +835,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 6,
     // Align with the left edge of the post content (text/image)
-    // Avatar width (32) + margin (8) + container padding (10)
-    left: 50,
+    // Avatar width (48) + margin (8) + container padding (10)
+    left: 66,
     flexDirection: 'row',
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  replyCountLarge: { fontSize: 15, color: 'gray' },
+  likeCountLarge: { fontSize: 15, color: 'gray' },
   likeContainer: {
     position: 'absolute',
     bottom: 6,

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -702,11 +702,11 @@ export default function ReplyDetailScreen() {
                 <View style={styles.replyCountContainer}>
                   <Ionicons
                     name="chatbubble-outline"
-                    size={12}
+                    size={18}
                     color="#66538f"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{replyCounts[originalPost.id] || 0}</Text>
+                  <Text style={styles.replyCountLarge}>{replyCounts[originalPost.id] || 0}</Text>
                 </View>
                 <TouchableOpacity
                   style={styles.likeContainer}
@@ -715,11 +715,11 @@ export default function ReplyDetailScreen() {
                   <Ionicons
                     name={likedItems[originalPost.id] ? 'heart' : 'heart-outline'}
 
-                    size={12}
+                    size={18}
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[originalPost.id] || 0}</Text>
+                  <Text style={styles.likeCountLarge}>{likeCounts[originalPost.id] || 0}</Text>
                 </TouchableOpacity>
 
               </View>
@@ -783,11 +783,11 @@ export default function ReplyDetailScreen() {
                 <View style={styles.replyCountContainer}>
                   <Ionicons
                     name="chatbubble-outline"
-                    size={12}
+                    size={18}
                     color="#66538f"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{replyCounts[a.id] || 0}</Text>
+                  <Text style={styles.replyCountLarge}>{replyCounts[a.id] || 0}</Text>
                 </View>
                 <TouchableOpacity
                   style={styles.likeContainer}
@@ -796,11 +796,11 @@ export default function ReplyDetailScreen() {
                   <Ionicons
                     name={likedItems[a.id] ? 'heart' : 'heart-outline'}
 
-                    size={12}
+                    size={18}
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[a.id] || 0}</Text>
+                  <Text style={styles.likeCountLarge}>{likeCounts[a.id] || 0}</Text>
                 </TouchableOpacity>
 
               </View>
@@ -856,11 +856,11 @@ export default function ReplyDetailScreen() {
           <View style={styles.replyCountContainer}>
             <Ionicons
               name="chatbubble-outline"
-              size={12}
+              size={18}
               color="#66538f"
               style={{ marginRight: 2 }}
             />
-            <Text style={styles.replyCount}>{replyCounts[parent.id] || 0}</Text>
+            <Text style={styles.replyCountLarge}>{replyCounts[parent.id] || 0}</Text>
           </View>
           <TouchableOpacity
             style={styles.likeContainer}
@@ -869,11 +869,11 @@ export default function ReplyDetailScreen() {
             <Ionicons
               name={likedItems[parent.id] ? 'heart' : 'heart-outline'}
 
-              size={12}
+              size={18}
               color="red"
               style={{ marginRight: 2 }}
             />
-            <Text style={styles.replyCount}>{likeCounts[parent.id] || 0}</Text>
+            <Text style={styles.likeCountLarge}>{likeCounts[parent.id] || 0}</Text>
           </TouchableOpacity>
 
           </View>
@@ -948,11 +948,11 @@ export default function ReplyDetailScreen() {
                 <View style={styles.replyCountContainer}>
                   <Ionicons
                     name="chatbubble-outline"
-                    size={12}
+                    size={18}
                     color="#66538f"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{replyCounts[item.id] || 0}</Text>
+                  <Text style={styles.replyCountLarge}>{replyCounts[item.id] || 0}</Text>
                 </View>
                 <TouchableOpacity
                   style={styles.likeContainer}
@@ -961,11 +961,11 @@ export default function ReplyDetailScreen() {
                   <Ionicons
                     name={likedItems[item.id] ? 'heart' : 'heart-outline'}
 
-                    size={12}
+                    size={18}
                     color="red"
                     style={{ marginRight: 2 }}
                   />
-                  <Text style={styles.replyCount}>{likeCounts[item.id] || 0}</Text>
+                  <Text style={styles.likeCountLarge}>{likeCounts[item.id] || 0}</Text>
                 </TouchableOpacity>
 
               </View>
@@ -1013,7 +1013,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   row: { flexDirection: 'row', alignItems: 'flex-start' },
-  avatar: { width: 32, height: 32, borderRadius: 16, marginRight: 8 },
+  avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 8 },
   placeholder: { backgroundColor: '#555' },
   reply: {
     backgroundColor: '#ffffff10',
@@ -1052,12 +1052,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 6,
     // Align with the left edge of the post content (text/image)
-    // Avatar width (32) + margin (8) + container padding (10)
-    left: 50,
+    // Avatar width (48) + margin (8) + container padding (10)
+    left: 66,
     flexDirection: 'row',
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
+  replyCountLarge: { fontSize: 15, color: 'gray' },
+  likeCountLarge: { fontSize: 15, color: 'gray' },
   likeContainer: {
     position: 'absolute',
     bottom: 6,


### PR DESCRIPTION
## Summary
- allow replying directly from HomeScreen by tapping the reply icon
- implement bottom reply modal with image picker and post action

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68406250b1b08322a98b9c2b17ec4ef3