### PR TITLE
Show user posts list on home feed

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -677,6 +677,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           );
         }}
       />
+      {user && (
+        <View style={styles.textListContainer}>
+          <Text style={styles.postsHeader}>Posts</Text>
+          <FlatList
+            data={posts.filter(p => p.user_id === user.id)}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <Text style={styles.postTextItem}>{item.content}</Text>
+            )}
+          />
+        </View>
+      )}
       <Modal visible={replyModalVisible} animationType="slide" transparent>
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -791,6 +803,19 @@ const styles = StyleSheet.create({
     height: 200,
     borderRadius: 6,
     marginTop: 8,
+  },
+  textListContainer: {
+    marginTop: 20,
+    paddingHorizontal: 16,
+  },
+  postsHeader: {
+    color: 'white',
+    fontSize: 18,
+    marginBottom: 10,
+  },
+  postTextItem: {
+    color: 'white',
+    marginBottom: 8,
   },
 
 });


### PR DESCRIPTION
## Summary
- add a flat list on the home feed that displays the logged-in user's post text
- style the new list section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841a590e4108322abdf60082e9b2ded