### PR TITLE
Refactor ProfileScreen to list user posts

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export interface Post {
+  id: string;
+  content: string;
+  image_url?: string;
+  username?: string;
+  user_id: string;
+  created_at: string;
+  reply_count?: number;
+  like_count?: number;
+  profiles?: {
+    username: string | null;
+    name: string | null;
+    image_url?: string | null;
+    banner_url?: string | null;
+  } | null;
+}
+
+interface PostCardProps {
+  post: Post;
+  replyCount: number;
+  likeCount: number;
+  liked: boolean;
+  avatarUri?: string;
+  showDelete?: boolean;
+  onPress?: () => void;
+  onDelete?: () => void;
+  onReplyPress?: () => void;
+  onToggleLike?: () => void;
+  onUserPress?: () => void;
+}
+
+function timeAgo(dateString: string): string {
+  const diff = Date.now() - new Date(dateString).getTime();
+  const minutes = Math.floor(diff / (1000 * 60));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function PostCard({
+  post,
+  replyCount,
+  likeCount,
+  liked,
+  avatarUri,
+  showDelete,
+  onPress,
+  onDelete,
+  onReplyPress,
+  onToggleLike,
+  onUserPress,
+}: PostCardProps) {
+  const displayName =
+    post.profiles?.name || post.profiles?.username || post.username;
+  const userName = post.profiles?.username || post.username;
+  const avatar = avatarUri ?? post.profiles?.image_url ?? undefined;
+
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <View style={styles.post}>
+        {showDelete && (
+          <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
+            <Text style={{ color: 'white' }}>X</Text>
+          </TouchableOpacity>
+        )}
+        <View style={styles.row}>
+          <TouchableOpacity onPress={onUserPress}>
+            {avatar ? (
+              <Image source={{ uri: avatar }} style={styles.avatar} />
+            ) : (
+              <View style={[styles.avatar, styles.placeholder]} />
+            )}
+          </TouchableOpacity>
+          <View style={{ flex: 1 }}>
+            <View style={styles.headerRow}>
+              <Text style={styles.username}>
+                {displayName} @{userName}
+              </Text>
+              <Text style={[styles.timestamp, styles.timestampMargin]}>
+                {timeAgo(post.created_at)}
+              </Text>
+            </View>
+            <Text style={styles.postContent}>{post.content}</Text>
+            {post.image_url && (
+              <Image source={{ uri: post.image_url }} style={styles.postImage} />
+            )}
+          </View>
+        </View>
+        <TouchableOpacity
+          style={styles.replyCountContainer}
+          onPress={onReplyPress}
+        >
+          <Ionicons
+            name="chatbubble-outline"
+            size={18}
+            color="#66538f"
+            style={{ marginRight: 2 }}
+          />
+          <Text style={styles.replyCountLarge}>{replyCount}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.likeContainer} onPress={onToggleLike}>
+          <Ionicons
+            name={liked ? 'heart' : 'heart-outline'}
+            size={18}
+            color="red"
+            style={{ marginRight: 2 }}
+          />
+          <Text
+            style={[styles.likeCountLarge, liked && styles.likedLikeCount]}
+          >
+            {likeCount}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  post: {
+    backgroundColor: '#ffffff10',
+    borderRadius: 0,
+    padding: 10,
+    paddingBottom: 30,
+    marginBottom: 0,
+    borderBottomColor: 'gray',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    position: 'relative',
+  },
+  row: { flexDirection: 'row', alignItems: 'flex-start' },
+  avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 8 },
+  placeholder: { backgroundColor: '#555' },
+  deleteButton: { position: 'absolute', right: 6, top: 6, padding: 4 },
+  postContent: { color: 'white' },
+  username: { fontWeight: 'bold', color: 'white' },
+  timestamp: { fontSize: 10, color: 'gray' },
+  headerRow: { flexDirection: 'row', alignItems: 'center' },
+  timestampMargin: { marginLeft: 6 },
+  replyCountContainer: {
+    position: 'absolute',
+    bottom: 6,
+    left: 66,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  replyCountLarge: { fontSize: 15, color: 'gray' },
+  likeCountLarge: { fontSize: 15, color: 'gray' },
+  likedLikeCount: { color: 'red' },
+  likeContainer: {
+    position: 'absolute',
+    bottom: 6,
+    left: '50%',
+    transform: [{ translateX: -6 }],
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  postImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginTop: 8,
+  },
+});

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -9,20 +9,19 @@ import {
   Alert,
   TouchableOpacity,
   Image,
-  ActivityIndicator,
   Modal,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
-import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
+import PostCard from '../components/PostCard';
 
 const STORAGE_KEY = 'cached_posts';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -49,16 +48,6 @@ type Post = {
   } | null;
 };
 
-function timeAgo(dateString: string): string {
-  const diff = Date.now() - new Date(dateString).getTime();
-  const minutes = Math.floor(diff / (1000 * 60));
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 export interface HomeScreenRef {
   createPost: (text: string, imageUri?: string) => Promise<void>;
@@ -584,96 +573,33 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         keyExtractor={(item) => item.id}
         
         renderItem={({ item }) => {
-          const displayName =
-            item.profiles?.name || item.profiles?.username || item.username;
-          const userName = item.profiles?.username || item.username;
           const isMe = user?.id === item.user_id;
           const avatarUri = isMe ? profileImageUri : item.profiles?.image_url || undefined;
-          const bannerUrl = isMe ? undefined : item.profiles?.banner_url || undefined;
 
           return (
-            <TouchableOpacity onPress={() => navigation.navigate('PostDetail', { post: item })}>
-              <View style={styles.post}>
-                {isMe && (
-                  <TouchableOpacity
-                    onPress={() => confirmDeletePost(item.id)}
-                    style={styles.deleteButton}
-                  >
-                    <Text style={{ color: 'white' }}>X</Text>
-                  </TouchableOpacity>
-                )}
-                <View style={styles.row}>
-                  <TouchableOpacity
-                    onPress={() =>
-                      isMe
-                        ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', {
-                            userId: item.user_id,
-                            avatarUrl: avatarUri,
-                            bannerUrl: item.profiles?.banner_url,
-
-                            name: displayName,
-                            username: userName,
-                          })
-                    }
-                  >
-                    {avatarUri ? (
-                      <Image source={{ uri: avatarUri }} style={styles.avatar} />
-                    ) : (
-                      <View style={[styles.avatar, styles.placeholder]} />
-                    )}
-                  </TouchableOpacity>
-
-                  <View style={{ flex: 1 }}>
-                    <View style={styles.headerRow}>
-                      <Text style={styles.username}>
-                        {displayName} @{userName}
-                      </Text>
-                      <Text style={[styles.timestamp, styles.timestampMargin]}>
-                        {timeAgo(item.created_at)}
-                      </Text>
-                    </View>
-                    <Text style={styles.postContent}>{item.content}</Text>
-                    {item.image_url && (
-                      <Image source={{ uri: item.image_url }} style={styles.postImage} />
-                    )}
-                  </View>
-                </View>
-                <TouchableOpacity
-                  style={styles.replyCountContainer}
-                  onPress={() => openReplyModal(item.id)}
-                >
-                  <Ionicons
-                    name="chatbubble-outline"
-                    size={18}
-                    color="#66538f"
-                    style={{ marginRight: 2 }}
-                  />
-                  <Text style={styles.replyCountLarge}>{replyCounts[item.id] || 0}</Text>
-                </TouchableOpacity>
-
-                <TouchableOpacity
-                  style={styles.likeContainer}
-                  onPress={() => toggleLike(item.id)}
-                >
-                  <Ionicons
-                    name={likedPosts[item.id] ? 'heart' : 'heart-outline'}
-                    size={18}
-                    color="red"
-                    style={{ marginRight: 2 }}
-                  />
-                  <Text
-                    style={[
-                      styles.likeCountLarge,
-                      likedPosts[item.id] && styles.likedLikeCount,
-                    ]}
-                  >
-                    {likeCounts[item.id] || 0}
-                  </Text>
-                </TouchableOpacity>
-
-              </View>
-            </TouchableOpacity>
+            <PostCard
+              post={item}
+              replyCount={replyCounts[item.id] || 0}
+              likeCount={likeCounts[item.id] || 0}
+              liked={!!likedPosts[item.id]}
+              avatarUri={avatarUri}
+              showDelete={isMe}
+              onPress={() => navigation.navigate('PostDetail', { post: item })}
+              onDelete={() => confirmDeletePost(item.id)}
+              onReplyPress={() => openReplyModal(item.id)}
+              onToggleLike={() => toggleLike(item.id)}
+              onUserPress={() =>
+                isMe
+                  ? navigation.navigate('Profile')
+                  : navigation.navigate('UserProfile', {
+                      userId: item.user_id,
+                      avatarUrl: avatarUri,
+                      bannerUrl: item.profiles?.banner_url,
+                      name: item.profiles?.name || item.profiles?.username || item.username,
+                      username: item.profiles?.username || item.username,
+                    })
+              }
+            />
           );
         }}
       />
@@ -754,9 +680,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   replyCount: { fontSize: 10, color: 'gray' },
-  replyCountLarge: { fontSize: 15, color: 'gray' },
-  likeCountLarge: { fontSize: 15, color: 'gray' },
-  likedLikeCount: { color: 'red' },
 
   likeContainer: {
     position: 'absolute',
@@ -785,12 +708,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginBottom: 10,
-  },
-  postImage: {
-    width: '100%',
-    height: 200,
-    borderRadius: 6,
-    marginTop: 8,
   },
 
 });

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -9,17 +9,17 @@ import {
   TouchableOpacity,
   Dimensions,
   Alert,
+  FlatList,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
 import { useNavigation } from '@react-navigation/native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Ionicons } from '@expo/vector-icons';
 
 import { useAuth } from '../../AuthContext';
 import { useFollowCounts } from '../hooks/useFollowCounts';
 import { colors } from '../styles/colors';
 import { supabase } from '../../lib/supabase';
+import PostCard from '../components/PostCard';
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
@@ -50,21 +50,11 @@ export default function ProfileScreen() {
     } | null;
   };
 
-  const [latestPost, setLatestPost] = useState<Post | null>(null);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
   const [likeCounts, setLikeCounts] = useState<{ [key: string]: number }>({});
   const [likedPosts, setLikedPosts] = useState<{ [key: string]: boolean }>({});
+  const [posts, setPosts] = useState<Post[]>([]);
 
-  function timeAgo(dateString: string): string {
-    const diff = Date.now() - new Date(dateString).getTime();
-    const minutes = Math.floor(diff / (1000 * 60));
-    if (minutes < 1) return 'just now';
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
-  }
 
   const refreshLikeCount = async (id: string) => {
     const { data } = await supabase
@@ -90,34 +80,73 @@ export default function ProfileScreen() {
     await refreshLikeCount(id);
   };
 
+  const handleDeletePost = async (id: string) => {
+    setPosts(prev => prev.filter(p => p.id !== id));
+    setReplyCounts(prev => {
+      const { [id]: _omit, ...rest } = prev;
+      return rest;
+    });
+    setLikeCounts(prev => {
+      const { [id]: _omit, ...rest } = prev;
+      return rest;
+    });
+    setLikedPosts(prev => {
+      const { [id]: _omit, ...rest } = prev;
+      return rest;
+    });
+    await supabase.from('posts').delete().eq('id', id);
+  };
+
+  const confirmDeletePost = (id: string) => {
+    Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: () => handleDeletePost(id) },
+    ]);
+  };
+
   useEffect(() => {
-    const fetchLatest = async () => {
+    const fetchPosts = async () => {
+      if (!profile) return;
       const { data, error } = await supabase
         .from('posts')
         .select(
-          'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, name, image_url, banner_url)',
+          'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, name, image_url, banner_url)'
         )
-        .order('created_at', { ascending: false })
-        .limit(1);
+        .eq('user_id', profile.id)
+        .order('created_at', { ascending: false });
 
-      if (!error && data && data.length > 0) {
-        const p = data[0] as Post;
-        setLatestPost(p);
-        setReplyCounts({ [p.id]: p.reply_count ?? 0 });
-        setLikeCounts({ [p.id]: p.like_count ?? 0 });
-        if (profile) {
-          const { data: likedData } = await supabase
-            .from('likes')
-            .select('post_id')
-            .eq('user_id', profile.id)
-            .eq('post_id', p.id);
-          if (likedData && likedData.length > 0) {
-            setLikedPosts({ [p.id]: true });
-          }
+      if (!error && data) {
+        const list = data as Post[];
+        setPosts(list);
+        setReplyCounts(prev => {
+          const counts = { ...prev };
+          list.forEach(p => {
+            counts[p.id] = p.reply_count ?? 0;
+          });
+          return counts;
+        });
+        setLikeCounts(prev => {
+          const counts = { ...prev };
+          list.forEach(p => {
+            counts[p.id] = p.like_count ?? 0;
+          });
+          return counts;
+        });
+        const { data: likedData } = await supabase
+          .from('likes')
+          .select('post_id')
+          .eq('user_id', profile.id)
+          .in('post_id', list.map(p => p.id));
+        if (likedData) {
+          const likedObj: { [key: string]: boolean } = {};
+          likedData.forEach(l => {
+            if (l.post_id) likedObj[l.post_id] = true;
+          });
+          setLikedPosts(prev => ({ ...prev, ...likedObj }));
         }
       }
     };
-    fetchLatest();
+    fetchPosts();
   }, [profile?.id]);
 
 
@@ -212,112 +241,26 @@ export default function ProfileScreen() {
         <Text style={styles.uploadText}>Upload Banner</Text>
       </TouchableOpacity>
 
-      {latestPost && (
-        <TouchableOpacity
-          onPress={() => navigation.navigate('PostDetail', { post: latestPost })}
-        >
-          <View style={styles.postContainer}>
-            <View style={styles.postRow}>
-              <TouchableOpacity
-                onPress={() =>
-                  latestPost.user_id === profile.id
-                    ? navigation.navigate('Profile')
-                    : navigation.navigate('UserProfile', {
-                        userId: latestPost.user_id,
-                        avatarUrl:
-                          latestPost.user_id === profile.id
-                            ? profileImageUri
-                            : latestPost.profiles?.image_url || undefined,
-                        bannerUrl:
-                          latestPost.user_id === profile.id
-                            ? undefined
-                            : latestPost.profiles?.banner_url || undefined,
-                        name:
-                          latestPost.profiles?.name ||
-                          latestPost.profiles?.username ||
-                          latestPost.username,
-                        username:
-                          latestPost.profiles?.username || latestPost.username,
-                      })
-                }
-              >
-                {latestPost.user_id === profile.id ? (
-                  profileImageUri ? (
-                    <Image
-                      source={{ uri: profileImageUri }}
-                      style={styles.postAvatar}
-                    />
-                  ) : (
-                    <View style={[styles.postAvatar, styles.postPlaceholder]} />
-                  )
-                ) : latestPost.profiles?.image_url ? (
-                  <Image
-                    source={{ uri: latestPost.profiles.image_url }}
-                    style={styles.postAvatar}
-                  />
-                ) : (
-                  <View style={[styles.postAvatar, styles.postPlaceholder]} />
-                )}
-              </TouchableOpacity>
-              <View style={{ flex: 1 }}>
-                <View style={styles.postHeaderRow}>
-                  <Text style={styles.postUsername}>
-                    {latestPost.profiles?.name ||
-                      latestPost.profiles?.username ||
-                      latestPost.username}{' '}
-                    @{
-                      latestPost.profiles?.username || latestPost.username || ''
-                    }
-                  </Text>
-                  <Text style={[styles.postTimestamp, styles.timestampMargin]}>
-                    {timeAgo(latestPost.created_at)}
-                  </Text>
-                </View>
-                <Text style={styles.postContent}>{latestPost.content}</Text>
-                {latestPost.image_url && (
-                  <Image
-                    source={{ uri: latestPost.image_url }}
-                    style={styles.postImage}
-                  />
-                )}
-              </View>
-            </View>
-            <TouchableOpacity
-              style={styles.replyCountContainer}
-              onPress={() => navigation.navigate('PostDetail', { post: latestPost })}
-            >
-              <Ionicons
-                name="chatbubble-outline"
-                size={18}
-                color="#66538f"
-                style={{ marginRight: 2 }}
-              />
-              <Text style={styles.replyCountLarge}>
-                {replyCounts[latestPost.id] || 0}
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.likeContainer}
-              onPress={() => toggleLike(latestPost.id)}
-            >
-              <Ionicons
-                name={likedPosts[latestPost.id] ? 'heart' : 'heart-outline'}
-                size={18}
-                color="red"
-                style={{ marginRight: 2 }}
-              />
-              <Text
-                style={[
-                  styles.likeCountLarge,
-                  likedPosts[latestPost.id] && styles.likedLikeCount,
-                ]}
-              >
-                {likeCounts[latestPost.id] || 0}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </TouchableOpacity>
-      )}
+      <FlatList
+        data={posts}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <PostCard
+            post={item}
+            replyCount={replyCounts[item.id] || 0}
+            likeCount={likeCounts[item.id] || 0}
+            liked={!!likedPosts[item.id]}
+            avatarUri={profileImageUri}
+            showDelete={item.user_id === profile.id}
+            onPress={() => navigation.navigate('PostDetail', { post: item })}
+            onDelete={() => confirmDeletePost(item.id)}
+            onReplyPress={() => navigation.navigate('PostDetail', { post: item })}
+            onToggleLike={() => toggleLike(item.id)}
+            onUserPress={() => navigation.navigate('Profile')}
+          />
+        )}
+        style={{ marginTop: 20 }}
+      />
     </View>
   );
 }
@@ -373,48 +316,5 @@ const styles = StyleSheet.create({
   uploadText: { color: 'white' },
   statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
   statsText: { color: 'white', marginRight: 15 },
-
-  postContainer: {
-    backgroundColor: '#ffffff10',
-    borderRadius: 0,
-    padding: 10,
-    paddingBottom: 30,
-    marginTop: 20,
-    borderBottomColor: 'gray',
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    position: 'relative',
-  },
-  postRow: { flexDirection: 'row', alignItems: 'flex-start' },
-  postAvatar: { width: 48, height: 48, borderRadius: 24, marginRight: 8 },
-  postPlaceholder: { backgroundColor: '#555' },
-  postHeaderRow: { flexDirection: 'row', alignItems: 'center' },
-  postUsername: { fontWeight: 'bold', color: 'white' },
-  postTimestamp: { fontSize: 10, color: 'gray' },
-  timestampMargin: { marginLeft: 6 },
-  postContent: { color: 'white' },
-  replyCountContainer: {
-    position: 'absolute',
-    bottom: 6,
-    left: 66,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  replyCountLarge: { fontSize: 15, color: 'gray' },
-  likeCountLarge: { fontSize: 15, color: 'gray' },
-  likedLikeCount: { color: 'red' },
-  likeContainer: {
-    position: 'absolute',
-    bottom: 6,
-    left: '50%',
-    transform: [{ translateX: -6 }],
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  postImage: {
-    width: '100%',
-    height: 200,
-    borderRadius: 6,
-    marginTop: 8,
-  },
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/react": "~19.0.10",
-        "typescript": "~5.8.3"
+        "typescript": "~5.8.3",
+        "@expo/tsconfig": "^1.0.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@expo/tsconfig": "^1.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- display a FlatList of the logged‑in user's posts on ProfileScreen
- remove unused profile helpers

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided, expo/tsconfig.base not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6841b1dca3188322b3721779acc457be