### PR TITLE
Fix tsconfig base resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
-  "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "jsx": "react",
+    "lib": ["esnext"],
+    "target": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
## Summary
- inline compiler options in `tsconfig.json` to avoid missing expo base config

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68428a77683c83229270acbbc0cb5072