### PR TITLE
Ensure text posts appear on profile immediately

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -10,6 +10,7 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const [profileImageUri, setProfileImageUriState] = useState(null);
   const [bannerImageUri, setBannerImageUriState] = useState(null);
+  const [myPosts, setMyPosts] = useState([]);
 
   // Helper ensures a profile exists for the given user so posts can
   // reference it without foreign-key errors
@@ -95,7 +96,11 @@ export function AuthProvider({ children }) {
     });
 
     return () => {
-      listener?.subscription.unsubscribe();
+      if (listener?.subscription) {
+        listener.subscription.unsubscribe();
+      } else {
+        listener?.unsubscribe?.();
+      }
     };
   }, []);
 
@@ -114,6 +119,7 @@ export function AuthProvider({ children }) {
       if (bannerStored) setBannerImageUriState(bannerStored);
     };
     loadImage();
+    fetchMyPosts();
   }, [user]);
 
   // 🔐 Sign in
@@ -189,6 +195,7 @@ export function AuthProvider({ children }) {
     setProfile(null);
     setProfileImageUriState(null);
     setBannerImageUriState(null);
+    setMyPosts([]);
   };
 
   const setProfileImageUri = async (uri) => {
@@ -239,6 +246,33 @@ export function AuthProvider({ children }) {
         .eq('id', user.id);
       if (error) console.error('Failed to update banner_url:', error);
     }
+  };
+
+  const fetchMyPosts = async () => {
+    const id = user?.id;
+    if (!id) {
+      setMyPosts([]);
+      return;
+    }
+    const { data, error } = await supabase
+      .from('posts')
+      .select('id, content')
+      .eq('user_id', id)
+      .order('created_at', { ascending: false });
+    if (!error && data) {
+      setMyPosts(prev => {
+        const temps = prev.filter(p => String(p.id).startsWith('temp-'));
+        return [...temps, ...data];
+      });
+    }
+  };
+
+  const addPost = (post) => {
+    setMyPosts((prev) => [post, ...prev]);
+  };
+
+  const updatePost = (tempId, updated) => {
+    setMyPosts(prev => prev.map(p => (p.id === tempId ? { ...p, ...updated } : p)));
   };
 
   // 🔍 Fetch profile by ID
@@ -304,6 +338,10 @@ export function AuthProvider({ children }) {
     setProfileImageUri,
     bannerImageUri,
     setBannerImageUri,
+    myPosts,
+    fetchMyPosts,
+    addPost,
+    updatePost,
     signUp,
     signIn,
     signOut,

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -71,7 +71,8 @@ interface HomeScreenProps {
 const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   ({ hideInput }, ref) => {
     const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri } = useAuth() as any;
+  const { user, profile, profileImageUri, bannerImageUri, addPost, updatePost } =
+    useAuth() as any;
   const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
@@ -384,6 +385,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       return counts;
     });
 
+    if (!imageUri) {
+      addPost({ id: newPost.id, content: text });
+    }
+
     if (!hideInput) {
       setPostText('');
     }
@@ -423,6 +428,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
           return updated;
         });
+        if (!imageUri) {
+          updatePost(newPost.id, { id: data.id, content: data.content });
+        }
         setReplyCounts(prev => {
           const { [newPost.id]: tempCount, ...rest } = prev;
           const counts = { ...rest, [data.id]: tempCount };

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import {
   View,
@@ -8,14 +8,16 @@ import {
   Image,
   TouchableOpacity,
   Dimensions,
+  FlatList,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 
 import { useAuth } from '../../AuthContext';
 import { useFollowCounts } from '../hooks/useFollowCounts';
 import { colors } from '../styles/colors';
+
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();
@@ -25,9 +27,17 @@ export default function ProfileScreen() {
     setProfileImageUri,
     bannerImageUri,
     setBannerImageUri,
+    myPosts: posts,
+    fetchMyPosts,
   } = useAuth() as any;
 
   const { followers, following } = useFollowCounts(profile?.id ?? null);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchMyPosts();
+    }, [fetchMyPosts]),
+  );
 
 
   const pickImage = async () => {
@@ -69,8 +79,8 @@ export default function ProfileScreen() {
 
   if (!profile) return null;
 
-  return (
-    <View style={styles.container}>
+  const renderHeader = () => (
+    <View>
       {bannerImageUri ? (
         <Image source={{ uri: bannerImageUri }} style={styles.banner} />
       ) : (
@@ -87,9 +97,7 @@ export default function ProfileScreen() {
         )}
         <View style={styles.textContainer}>
           <Text style={styles.username}>@{profile.username}</Text>
-          {profile.name && (
-            <Text style={styles.name}>{profile.name}</Text>
-          )}
+          {profile.name && <Text style={styles.name}>{profile.name}</Text>}
         </View>
       </View>
       <View style={styles.statsRow}>
@@ -122,13 +130,30 @@ export default function ProfileScreen() {
       </TouchableOpacity>
     </View>
   );
+
+  return (
+    <FlatList
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      data={posts}
+      ListHeaderComponent={renderHeader}
+      keyExtractor={item => item.id}
+      renderItem={({ item }) => (
+        <View style={styles.postItem}>
+          <Text style={styles.postContent}>{item.content}</Text>
+        </View>
+      )}
+    />
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 20,
     backgroundColor: colors.background,
+  },
+  contentContainer: {
+    padding: 20,
   },
   backButton: {
     alignSelf: 'flex-start',
@@ -175,5 +200,12 @@ const styles = StyleSheet.create({
   uploadText: { color: 'white' },
   statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
   statsText: { color: 'white', marginRight: 15 },
+  postItem: {
+    backgroundColor: '#ffffff10',
+    padding: 10,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  postContent: { color: 'white' },
 
 });


### PR DESCRIPTION
## Summary
- support updating `myPosts` entries in AuthContext
- optimistically push new text posts to `myPosts` when posting on HomeScreen
- replace temporary post id with the real one once the server responds
- merge local posts when fetching from server
- simplify ProfileScreen's auth hook usage

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6842ce80590483229a3864c014f226ad