### PR TITLE
Fix duplicate post display in profile screen

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -263,7 +263,13 @@ export function AuthProvider({ children }) {
     if (!error && data) {
       setMyPosts(prev => {
         const temps = prev.filter(p => String(p.id).startsWith('temp-'));
-        return [...temps, ...data];
+        const merged = [...temps, ...data];
+        const seen = new Set();
+        return merged.filter(p => {
+          if (seen.has(p.id)) return false;
+          seen.add(p.id);
+          return true;
+        });
       });
     }
 
@@ -274,7 +280,17 @@ export function AuthProvider({ children }) {
   };
 
   const updatePost = (tempId, updated) => {
-    setMyPosts(prev => prev.map(p => (p.id === tempId ? { ...p, ...updated } : p)));
+    setMyPosts(prev => {
+      const updatedList = prev.map(p =>
+        p.id === tempId ? { ...p, ...updated } : p
+      );
+      const seen = new Set();
+      return updatedList.filter(p => {
+        if (seen.has(p.id)) return false;
+        seen.add(p.id);
+        return true;
+      });
+    });
   };
 
 

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -83,6 +83,7 @@ export default function PostDetailScreen() {
   const navigation = useNavigation<any>();
   const { user, profile, profileImageUri, bannerImageUri } = useAuth() as any;
   const post = route.params.post as Post;
+  const fromProfile = route.params?.fromProfile ?? false;
 
   const STORAGE_KEY = `${REPLY_STORAGE_PREFIX}${post.id}`;
 
@@ -597,7 +598,10 @@ export default function PostDetailScreen() {
       keyboardVerticalOffset={80}
     >
       <View style={styles.backButton}>
-        <Button title="Return" onPress={() => navigation.goBack()} />
+        <Button
+          title="Return"
+          onPress={() => (fromProfile ? navigation.navigate('Profile') : navigation.goBack())}
+        />
       </View>
       <FlatList
         ListHeaderComponent={() => (

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -151,16 +151,7 @@ export default function ProfileScreen() {
         <Text style={styles.uploadText}>Upload Banner</Text>
       </TouchableOpacity>
 
-      <FlatList
-        data={posts}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.postItem}>
-            <Text style={styles.postContent}>{item.content}</Text>
-          </View>
-        )}
-        style={{ marginTop: 20 }}
-      />
+      {/* Removed duplicate post list */}
     </View>
   );
 
@@ -173,29 +164,34 @@ export default function ProfileScreen() {
       ListHeaderComponent={renderHeader}
       keyExtractor={item => item.id}
       renderItem={({ item }) => (
-        <View style={styles.postItem}>
-          <View style={styles.row}>
-            {profileImageUri ? (
-              <Image source={{ uri: profileImageUri }} style={styles.postAvatar} />
-            ) : (
-              <View style={[styles.postAvatar, styles.placeholder]} />
-            )}
-            <View style={{ flex: 1 }}>
-              <View style={styles.headerRow}>
-                <Text style={styles.postUsername}>
-                  {profile.name || profile.username} @{profile.username}
-                </Text>
-                {item.created_at && (
-                  <Text style={[styles.timestamp, styles.timestampMargin]}>
-                    {timeAgo(item.created_at)}
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('PostDetail', { post: item, fromProfile: true })
+          }
+        >
+          <View style={styles.postItem}>
+            <View style={styles.row}>
+              {profileImageUri ? (
+                <Image source={{ uri: profileImageUri }} style={styles.postAvatar} />
+              ) : (
+                <View style={[styles.postAvatar, styles.placeholder]} />
+              )}
+              <View style={{ flex: 1 }}>
+                <View style={styles.headerRow}>
+                  <Text style={styles.postUsername}>
+                    {profile.name || profile.username} @{profile.username}
                   </Text>
-                )}
+                  {item.created_at && (
+                    <Text style={[styles.timestamp, styles.timestampMargin]}>
+                      {timeAgo(item.created_at)}
+                    </Text>
+                  )}
+                </View>
+                <Text style={styles.postContent}>{item.content}</Text>
               </View>
-              <Text style={styles.postContent}>{item.content}</Text>
             </View>
           </View>
-
-        </View>
+        </TouchableOpacity>
       )}
     />
   );


### PR DESCRIPTION
## Summary
- remove duplicate list from profile screen
- deduplicate posts when fetching and updating
- link profile posts to their detail screen
- return to profile when opening detail from profile

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842fae799808322b6200058f7114a2f