### PR TITLE
Sync profile post reply counts with feed

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -256,17 +256,25 @@ export function AuthProvider({ children }) {
     }
     const { data, error } = await supabase
       .from('posts')
-      .select('id, content, created_at')
-
+      .select('id, content, created_at, reply_count')
       .eq('user_id', id)
       .order('created_at', { ascending: false });
+
     if (!error && data) {
       setMyPosts(prev => {
         const temps = prev.filter(p => String(p.id).startsWith('temp-'));
-        return [...temps, ...data];
+        const combined = [...temps, ...data];
+        const seen = new Set();
+        const unique = [];
+        for (const p of combined) {
+          if (!seen.has(p.id)) {
+            seen.add(p.id);
+            unique.push(p);
+          }
+        }
+        return unique;
       });
     }
-
   };
 
   const addPost = (post) => {
@@ -274,7 +282,18 @@ export function AuthProvider({ children }) {
   };
 
   const updatePost = (tempId, updated) => {
-    setMyPosts(prev => prev.map(p => (p.id === tempId ? { ...p, ...updated } : p)));
+    setMyPosts(prev => {
+      const mapped = prev.map(p => (p.id === tempId ? { ...p, ...updated } : p));
+      const seen = new Set();
+      const unique = [];
+      for (const post of mapped) {
+        if (!seen.has(post.id)) {
+          seen.add(post.id);
+          unique.push(post);
+        }
+      }
+      return unique;
+    });
   };
 
 

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -387,8 +387,12 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     });
 
     if (!imageUri) {
-      addPost({ id: newPost.id, content: text, created_at: newPost.created_at });
-
+      addPost({
+        id: newPost.id,
+        content: text,
+        created_at: newPost.created_at,
+        reply_count: 0,
+      });
     }
 
     if (!hideInput) {
@@ -435,8 +439,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
             id: data.id,
             content: data.content,
             created_at: data.created_at,
+            reply_count: 0,
           });
-
         }
         setReplyCounts(prev => {
           const { [newPost.id]: tempCount, ...rest } = prev;

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
 
 import {
@@ -11,17 +11,19 @@ import {
   Dimensions,
   FlatList,
 } from 'react-native';
+import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useAuth } from '../../AuthContext';
 import { useFollowCounts } from '../hooks/useFollowCounts';
 import { colors } from '../styles/colors';
+
 import { supabase } from '../../lib/supabase';
 
-
-
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 
 
@@ -52,10 +54,23 @@ export default function ProfileScreen() {
     fetchMyPosts,
   } = useAuth() as any;
 
+  const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
+
   const { followers, following } = useFollowCounts(profile?.id ?? null);
 
   useFocusEffect(
     useCallback(() => {
+      const loadCounts = async () => {
+        const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+        if (stored) {
+          try {
+            setReplyCounts(JSON.parse(stored));
+          } catch (e) {
+            console.error('Failed to parse cached counts', e);
+          }
+        }
+      };
+      loadCounts();
       fetchMyPosts();
     }, [fetchMyPosts]),
   );
@@ -102,7 +117,7 @@ export default function ProfileScreen() {
   if (!profile) return null;
 
   const renderHeader = () => (
-    <View>
+    <View style={styles.headerContainer}>
       {bannerImageUri ? (
         <Image source={{ uri: bannerImageUri }} style={styles.banner} />
       ) : (
@@ -151,16 +166,7 @@ export default function ProfileScreen() {
         <Text style={styles.uploadText}>Upload Banner</Text>
       </TouchableOpacity>
 
-      <FlatList
-        data={posts}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.postItem}>
-            <Text style={styles.postContent}>{item.content}</Text>
-          </View>
-        )}
-        style={{ marginTop: 20 }}
-      />
+      {/* Removed duplicate post list */}
     </View>
   );
 
@@ -173,29 +179,43 @@ export default function ProfileScreen() {
       ListHeaderComponent={renderHeader}
       keyExtractor={item => item.id}
       renderItem={({ item }) => (
-        <View style={styles.postItem}>
-          <View style={styles.row}>
-            {profileImageUri ? (
-              <Image source={{ uri: profileImageUri }} style={styles.postAvatar} />
-            ) : (
-              <View style={[styles.postAvatar, styles.placeholder]} />
-            )}
-            <View style={{ flex: 1 }}>
-              <View style={styles.headerRow}>
-                <Text style={styles.postUsername}>
-                  {profile.name || profile.username} @{profile.username}
-                </Text>
-                {item.created_at && (
-                  <Text style={[styles.timestamp, styles.timestampMargin]}>
-                    {timeAgo(item.created_at)}
+        <TouchableOpacity
+          onPress={() => navigation.navigate('PostDetail', { post: item })}
+        >
+          <View style={styles.postItem}>
+            <View style={styles.row}>
+              {profileImageUri ? (
+                <Image source={{ uri: profileImageUri }} style={styles.postAvatar} />
+              ) : (
+                <View style={[styles.postAvatar, styles.placeholder]} />
+              )}
+              <View style={{ flex: 1 }}>
+                <View style={styles.headerRow}>
+                  <Text style={styles.postUsername}>
+                    {profile.name || profile.username} @{profile.username}
                   </Text>
-                )}
+                  {item.created_at && (
+                    <Text style={[styles.timestamp, styles.timestampMargin]}>
+                      {timeAgo(item.created_at)}
+                    </Text>
+                  )}
+                </View>
+                <Text style={styles.postContent}>{item.content}</Text>
               </View>
-              <Text style={styles.postContent}>{item.content}</Text>
+            </View>
+            <View style={styles.replyCountContainer}>
+              <Ionicons
+                name="chatbubble-outline"
+                size={18}
+                color="#66538f"
+                style={{ marginRight: 2 }}
+              />
+              <Text style={styles.replyCountLarge}>
+                {replyCounts[item.id] ?? item.reply_count ?? 0}
+              </Text>
             </View>
           </View>
-
-        </View>
+        </TouchableOpacity>
       )}
     />
   );
@@ -207,7 +227,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   contentContainer: {
-    padding: 20,
+    padding: 0,
   },
   backButton: {
     alignSelf: 'flex-start',
@@ -256,9 +276,13 @@ const styles = StyleSheet.create({
   statsText: { color: 'white', marginRight: 15 },
   postItem: {
     backgroundColor: '#ffffff10',
+    borderRadius: 0,
     padding: 10,
-    borderRadius: 6,
-    marginBottom: 10,
+    paddingBottom: 30,
+    marginBottom: 0,
+    borderBottomColor: 'gray',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    position: 'relative',
   },
   postContent: { color: 'white' },
   postUsername: { fontWeight: 'bold', color: 'white' },
@@ -267,6 +291,17 @@ const styles = StyleSheet.create({
   headerRow: { flexDirection: 'row', alignItems: 'center' },
   timestamp: { fontSize: 10, color: 'gray' },
   timestampMargin: { marginLeft: 6 },
+  replyCountContainer: {
+    position: "absolute",
+    bottom: 6,
+    left: 66,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  replyCountLarge: { fontSize: 15, color: "gray" },
+  headerContainer: {
+    padding: 20,
+  },
 
 
 });


### PR DESCRIPTION
## Summary
- include `reply_count` when fetching profile posts and deduplicate results
- store `reply_count` when adding new posts
- keep myPosts unique when updating post IDs
- load cached reply counts on the profile screen and display them

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842fae799808322b6200058f7114a2f