### PR TITLE
Fix reply count sync between screens

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -180,20 +180,25 @@ export default function ProfileScreen() {
 
       ListHeaderComponent={renderHeader}
       keyExtractor={item => item.id}
-      renderItem={({ item }) => (
-        <PostCard
-          post={item}
-          isMe={true}
-          avatarUri={profileImageUri || undefined}
-          displayName={profile.name || profile.username}
-          userName={profile.username}
-          onPress={() => navigation.navigate('PostDetail', { post: item })}
-          onAvatarPress={() => {}}
-          onReplyPress={() => navigation.navigate('PostDetail', { post: item })}
-          rounded
-        />
+      renderItem={({ item }) => {
+        const count = replyCounts[item.id];
+        const postWithCount = { ...item, reply_count: count ?? item.reply_count };
 
-      )}
+        return (
+          <PostCard
+            post={postWithCount}
+            isMe={true}
+            avatarUri={profileImageUri || undefined}
+            displayName={profile.name || profile.username}
+            userName={profile.username}
+            onPress={() => navigation.navigate('PostDetail', { post: item })}
+            onAvatarPress={() => {}}
+            onReplyPress={() => navigation.navigate('PostDetail', { post: item })}
+            rounded
+          />
+        );
+
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- show cached reply counts on ProfileScreen posts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843629b5eb48322bb1bf76306f3cab1