### PR TITLE
Keep profile post reply counts in sync

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -386,10 +386,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       return counts;
     });
 
-    if (!imageUri) {
-      addPost({ id: newPost.id, content: text, created_at: newPost.created_at });
-
-    }
+    // Cache the new post for the profile screen as well
+    addPost({ id: newPost.id, content: text, created_at: newPost.created_at });
 
     if (!hideInput) {
       setPostText('');
@@ -430,14 +428,12 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
           return updated;
         });
-        if (!imageUri) {
-          updatePost(newPost.id, {
-            id: data.id,
-            content: data.content,
-            created_at: data.created_at,
-          });
-
-        }
+        // Update cached profile posts with the real data
+        updatePost(newPost.id, {
+          id: data.id,
+          content: data.content,
+          created_at: data.created_at,
+        });
         setReplyCounts(prev => {
           const { [newPost.id]: tempCount, ...rest } = prev;
           const counts = { ...rest, [data.id]: tempCount };
@@ -451,15 +447,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
           return counts;
         });
-        setLikeCounts(prev => {
-          const { [newPost.id]: tempLike, ...rest } = prev;
-          const counts = { ...rest, [data.id]: tempLike ?? 0 };
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-          return counts;
-        });
       }
 
-      // Refresh from the server in the background to stay in sync
+      // Refresh from the server in the background to keep the feed up to date
       fetchPosts(0);
 
     } else {

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 
 
 import {
@@ -15,11 +15,15 @@ import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useAuth } from '../../AuthContext';
 import { useFollowCounts } from '../hooks/useFollowCounts';
 import { colors } from '../styles/colors';
 import { supabase } from '../../lib/supabase';
+
+
+const COUNT_STORAGE_KEY = 'cached_reply_counts';
 
 
 
@@ -53,11 +57,38 @@ export default function ProfileScreen() {
     fetchMyPosts,
   } = useAuth() as any;
 
+  const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
+
   const { followers, following } = useFollowCounts(profile?.id ?? null);
+
+  useEffect(() => {
+    const loadCounts = async () => {
+      const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+      if (stored) {
+        try {
+          setReplyCounts(JSON.parse(stored));
+        } catch (e) {
+          console.error('Failed to parse cached counts', e);
+        }
+      }
+    };
+    loadCounts();
+  }, []);
 
   useFocusEffect(
     useCallback(() => {
       fetchMyPosts();
+      const syncCounts = async () => {
+        const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
+        if (stored) {
+          try {
+            setReplyCounts(JSON.parse(stored));
+          } catch (e) {
+            console.error('Failed to parse cached counts', e);
+          }
+        }
+      };
+      syncCounts();
     }, [fetchMyPosts]),
   );
 
@@ -192,7 +223,7 @@ export default function ProfileScreen() {
             </View>
             <View style={styles.replyCountContainer}>
               <Ionicons name="chatbubble-outline" size={18} color="#66538f" style={{ marginRight: 2 }} />
-              <Text style={styles.replyCountLarge}>{item.reply_count || 0}</Text>
+              <Text style={styles.replyCountLarge}>{replyCounts[item.id] ?? item.reply_count ?? 0}</Text>
             </View>
 
           </View>


### PR DESCRIPTION
## Summary
- read cached reply counts in `ProfileScreen`
- show the stored counts for each post
- keep counts up to date whenever the profile screen is focused
- update post creation to show new posts on For You feed immediately
- refresh home feed from server after posting

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise')*

------
https://chatgpt.com/codex/tasks/task_e_6843ea67eed48322927de5c261a67f14