### PR TITLE
Fix reply count sync

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -329,8 +329,14 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       });
 
       const replyCountsMap = Object.fromEntries(replyEntries);
-      setReplyCounts(replyCountsMap);
-      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(replyCountsMap));
+      setReplyCounts(prev => {
+        const merged: { [key: string]: number } = { ...prev };
+        for (const [id, count] of Object.entries(replyCountsMap)) {
+          merged[id] = Math.max(prev[id] ?? 0, count);
+        }
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(merged));
+        return merged;
+      });
       const likeMap = Object.fromEntries(likeEntries);
       setLikeCounts(likeMap);
       AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));


### PR DESCRIPTION
## Summary
- ensure reply count from server doesn't overwrite local increments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68442c137f0083228ba0686471fad24e