### PR TITLE
Add reply event emitter

### DIFF
--- a/app/replyEvents.ts
+++ b/app/replyEvents.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'events';
+
+export const replyEvents = new EventEmitter();

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -23,6 +23,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
+import { replyEvents } from '../replyEvents';
 
 const STORAGE_KEY = 'cached_posts';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -502,6 +503,20 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   useImperativeHandle(ref, () => ({
     createPost,
   }));
+
+  useEffect(() => {
+    const onReplyAdded = (postId: string) => {
+      setReplyCounts(prev => {
+        const updated = { ...prev, [postId]: (prev[postId] || 0) + 1 };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+    };
+    replyEvents.on('replyAdded', onReplyAdded);
+    return () => {
+      replyEvents.off('replyAdded', onReplyAdded);
+    };
+  }, []);
 
   useEffect(() => {
     const loadCached = async () => {

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -22,6 +22,7 @@ import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/nativ
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
+import { replyEvents } from '../replyEvents';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -516,6 +517,7 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
+    replyEvents.emit('replyAdded', post.id);
     setLikeCounts(prev => {
       const counts = { ...prev, [newReply.id]: 0 };
       AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));


### PR DESCRIPTION
## Summary
- create an `EventEmitter` singleton for reply events
- emit a `replyAdded` event from `PostDetailScreen`
- update `HomeScreen` when `replyAdded` fires

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6844330771c88322a793259d54a83ff7