### PR TITLE
Implement global like store for posts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './AuthContext';
 import Navigator from './Navigator';
+import { PostStoreProvider } from './app/contexts/PostStoreContext';
 
 import { Buffer } from 'buffer';
 import process from 'process';
@@ -12,9 +13,11 @@ global.process = process;
 export default function App() {
   return (
     <AuthProvider>
-      <NavigationContainer>
-        <Navigator />
-      </NavigationContainer>
+      <PostStoreProvider>
+        <NavigationContainer>
+          <Navigator />
+        </NavigationContainer>
+      </PostStoreProvider>
     </AuthProvider>
   );
 }

--- a/AuthContext.js
+++ b/AuthContext.js
@@ -256,8 +256,7 @@ export function AuthProvider({ children }) {
     }
     const { data, error } = await supabase
       .from('posts')
-      .select('id, content, created_at, reply_count')
-
+      .select('id, content, created_at, reply_count, like_count')
       .eq('user_id', id)
       .order('created_at', { ascending: false });
     if (!error && data) {

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
+import useLike from '../hooks/useLike';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../styles/colors';
 
@@ -37,11 +38,8 @@ export interface PostCardProps {
   avatarUri?: string;
   bannerUrl?: string;
   replyCount: number;
-  likeCount: number;
-  liked: boolean;
   onPress: () => void;
   onProfilePress: () => void;
-  onToggleLike: () => void;
   onDelete: () => void;
   onOpenReplies: () => void;
 }
@@ -51,16 +49,15 @@ export default function PostCard({
   isOwner,
   avatarUri,
   replyCount,
-  likeCount,
-  liked,
   onPress,
   onProfilePress,
-  onToggleLike,
   onDelete,
   onOpenReplies,
 }: PostCardProps) {
   const displayName = post.profiles?.name || post.profiles?.username || post.username;
   const userName = post.profiles?.username || post.username;
+  const isReply = (post as any).post_id !== undefined;
+  const { likeCount, liked, toggleLike } = useLike(post.id, isReply);
 
   return (
     <TouchableOpacity onPress={onPress}>
@@ -97,7 +94,7 @@ export default function PostCard({
           <Ionicons name="chatbubble-outline" size={18} color="#66538f" style={{ marginRight: 2 }} />
           <Text style={styles.replyCountLarge}>{replyCount}</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.likeContainer} onPress={onToggleLike}>
+        <TouchableOpacity style={styles.likeContainer} onPress={toggleLike}>
           <Ionicons name={liked ? 'heart' : 'heart-outline'} size={18} color="red" style={{ marginRight: 2 }} />
           <Text style={[styles.likeCountLarge, liked && styles.likedLikeCount]}>{likeCount}</Text>
         </TouchableOpacity>

--- a/app/contexts/PostStoreContext.tsx
+++ b/app/contexts/PostStoreContext.tsx
@@ -1,0 +1,157 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { supabase } from '../../lib/supabase';
+import { useAuth } from '../../AuthContext';
+
+const LIKE_COUNT_KEY = 'cached_like_counts';
+const LIKED_KEY_PREFIX = 'cached_likes_';
+
+interface PostState {
+  likeCount: number;
+  liked: boolean;
+}
+
+interface ItemInfo {
+  id: string;
+  like_count?: number | null;
+}
+
+interface PostStore {
+  posts: Record<string, PostState>;
+  initialize: (items: ItemInfo[]) => Promise<void>;
+  toggleLike: (id: string, isReply?: boolean) => Promise<void>;
+  remove: (id: string) => void;
+}
+
+const PostStoreContext = createContext<PostStore | undefined>(undefined);
+
+export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { user } = useAuth() as any;
+  const [posts, setPosts] = useState<Record<string, PostState>>({});
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
+        const likeMap = likeStored ? JSON.parse(likeStored) : {};
+        let likedMap: Record<string, boolean> = {};
+        if (user) {
+          const likedStored = await AsyncStorage.getItem(
+            `${LIKED_KEY_PREFIX}${user.id}`,
+          );
+          likedMap = likedStored ? JSON.parse(likedStored) : {};
+        }
+        const merged: Record<string, PostState> = {};
+        Object.keys(likeMap).forEach(id => {
+          merged[id] = { likeCount: likeMap[id], liked: !!likedMap[id] };
+        });
+        setPosts(merged);
+      } catch (e) {
+        console.error('Failed to load post store', e);
+      }
+    };
+    load();
+  }, [user]);
+
+  const initialize = async (items: ItemInfo[]) => {
+    setPosts(prev => {
+      const updated = { ...prev };
+      items.forEach(item => {
+        const existing = updated[item.id];
+        const likeCount = item.like_count ?? existing?.likeCount ?? 0;
+        const liked = existing?.liked ?? false;
+        updated[item.id] = { likeCount, liked };
+      });
+      return updated;
+    });
+    try {
+      const stored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
+      const map = stored ? JSON.parse(stored) : {};
+      items.forEach(i => {
+        map[i.id] = i.like_count ?? map[i.id] ?? 0;
+      });
+      await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
+    } catch (e) {
+      console.error('Failed to persist like counts', e);
+    }
+  };
+
+  const toggleLike = async (id: string, isReply: boolean = false) => {
+    if (!user) return;
+    const current = posts[id] || { likeCount: 0, liked: false };
+    const newLiked = !current.liked;
+    let newCount = current.likeCount + (newLiked ? 1 : -1);
+    setPosts(prev => ({ ...prev, [id]: { likeCount: newCount, liked: newLiked } }));
+
+    try {
+      const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
+      const likeMap = likeStored ? JSON.parse(likeStored) : {};
+      likeMap[id] = newCount;
+      await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
+
+      const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
+      const likedMap = likedStored ? JSON.parse(likedStored) : {};
+      if (newLiked) {
+        likedMap[id] = true;
+      } else {
+        delete likedMap[id];
+      }
+      await AsyncStorage.setItem(
+        `${LIKED_KEY_PREFIX}${user.id}`,
+        JSON.stringify(likedMap),
+      );
+
+      if (id.startsWith('temp-')) {
+        // Don't sync with Supabase until the item has a real UUID
+        return;
+      }
+
+      if (newLiked) {
+        await supabase
+          .from('likes')
+          .insert({ user_id: user.id, [isReply ? 'reply_id' : 'post_id']: id });
+      } else {
+        await supabase
+          .from('likes')
+          .delete()
+          .match({ user_id: user.id, [isReply ? 'reply_id' : 'post_id']: id });
+      }
+      const { count } = await supabase
+        .from('likes')
+        .select('id', { count: 'exact', head: true })
+        .match(isReply ? { reply_id: id } : { post_id: id });
+      if (typeof count === 'number') {
+        newCount = count;
+        setPosts(prev => ({
+          ...prev,
+          [id]: { likeCount: count, liked: newLiked },
+        }));
+        likeMap[id] = count;
+        await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
+      }
+    } catch (e) {
+      console.error('Failed to toggle like', e);
+    }
+  };
+
+  const remove = (id: string) => {
+    setPosts(prev => {
+      const { [id]: _omit, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  return (
+    <PostStoreContext.Provider value={{ posts, initialize, toggleLike, remove }}>
+      {children}
+    </PostStoreContext.Provider>
+  );
+};
+
+export function usePostStore() {
+  const ctx = useContext(PostStoreContext);
+  if (!ctx) throw new Error('usePostStore must be used within PostStoreProvider');
+  return ctx;
+}

--- a/app/hooks/useLike.ts
+++ b/app/hooks/useLike.ts
@@ -1,0 +1,8 @@
+import { usePostStore } from '../contexts/PostStoreContext';
+
+export default function useLike(id: string, isReply: boolean = false) {
+  const { posts, toggleLike } = usePostStore();
+  const likeCount = posts[id]?.likeCount ?? 0;
+  const liked = posts[id]?.liked ?? false;
+  return { likeCount, liked, toggleLike: () => toggleLike(id, isReply) };
+}

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -17,6 +17,7 @@ import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useAuth } from '../../AuthContext';
+import { usePostStore } from '../contexts/PostStoreContext';
 import { useFollowCounts } from '../hooks/useFollowCounts';
 import { colors } from '../styles/colors';
 import { supabase } from '../../lib/supabase';
@@ -46,10 +47,17 @@ export default function ProfileScreen() {
     myPosts: posts,
     fetchMyPosts,
   } = useAuth() as any;
+  const { initialize } = usePostStore();
 
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
 
   const { followers, following } = useFollowCounts(profile?.id ?? null);
+
+  useEffect(() => {
+    if (posts && posts.length) {
+      initialize(posts.map(p => ({ id: p.id, like_count: p.like_count ?? 0 })));
+    }
+  }, [posts]);
 
   useEffect(() => {
     const loadCounts = async () => {
@@ -192,11 +200,8 @@ export default function ProfileScreen() {
           avatarUri={profileImageUri ?? undefined}
           bannerUrl={bannerImageUri ?? undefined}
           replyCount={replyCounts[item.id] ?? item.reply_count ?? 0}
-          likeCount={item.like_count ?? 0}
-          liked={false}
           onPress={() => navigation.navigate('PostDetail', { post: item })}
           onProfilePress={() => navigation.navigate('Profile')}
-          onToggleLike={() => {}}
           onDelete={() => {}}
           onOpenReplies={() => {}}
         />


### PR DESCRIPTION
## Summary
- fetch `like_count` when loading profile posts
- initialize global like state in ProfileScreen

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68443ec7c71883229fff3c04af0d2b8f