### PR TITLE
Fix like store cleanup

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -254,8 +254,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         return merged;
       });
       const likeMap = Object.fromEntries(likeEntries);
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-      initialize(data.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 })));
+      initialize(data.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 }))); 
 
 
       if (user) {
@@ -430,8 +429,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           setReplyCounts(Object.fromEntries(entries));
       const likeEntries = cached.map((p: any) => [p.id, p.like_count ?? 0]);
       const likeMap = Object.fromEntries(likeEntries);
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-      initialize(cached.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 })));
+      initialize(cached.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 }))); 
 
 
         } catch (e) {

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -150,24 +150,6 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-    if (likeStored) {
-      try {
-        const map = JSON.parse(likeStored);
-        delete map[id];
-        await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
-      } catch {}
-    }
-    if (user) {
-      const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user?.id}`);
-      if (likedStored) {
-        try {
-          const map = JSON.parse(likedStored);
-          delete map[id];
-          await AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user.id}`, JSON.stringify(map));
-        } catch {}
-      }
-    }
     remove(id);
 
     await supabase.from('replies').delete().eq('id', id);
@@ -275,7 +257,6 @@ export default function PostDetailScreen() {
       likeEntries.push([post.id, postLikeCount]);
 
       const counts = Object.fromEntries(likeEntries) as Record<string, number>;
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
       initialize([
         { id: post.id, like_count: postLikeCount },
         ...all.map(r => ({ id: r.id, like_count: r.like_count ?? 0 })),
@@ -367,7 +348,6 @@ export default function PostDetailScreen() {
             ...Object.fromEntries(likeEntries),
             ...storedLikes,
           } as Record<string, number>;
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeCountsObj));
           initialize([
             { id: post.id, like_count: storedLikes[post.id] ?? post.like_count ?? 0 },
             ...cached.map((r: any) => ({ id: r.id, like_count: r.like_count ?? 0 })),
@@ -377,7 +357,6 @@ export default function PostDetailScreen() {
         }
       } else {
         setReplyCounts(storedCounts);
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(storedLikes));
         initialize([
           { id: post.id, like_count: storedLikes[post.id] ?? post.like_count ?? 0 },
         ]);
@@ -457,10 +436,6 @@ export default function PostDetailScreen() {
     });
     initialize([{ id: newReply.id, like_count: 0 }]);
     replyEvents.emit('replyAdded', post.id);
-    const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-    const map = likeStored ? JSON.parse(likeStored) : {};
-    map[newReply.id] = 0;
-    AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
     setReplyText('');
     setReplyImage(null);
 
@@ -510,13 +485,7 @@ export default function PostDetailScreen() {
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
           return counts;
         });
-        const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-        const map = likeStored ? JSON.parse(likeStored) : {};
-        const temp = map[newReply.id] ?? 0;
-        delete map[newReply.id];
-        map[data.id] = temp;
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
-        initialize([{ id: data.id, like_count: temp }]);
+        initialize([{ id: data.id, like_count: 0 }]);
 
 
       }

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -199,18 +199,8 @@ export default function ReplyDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-    const likeMap = likeStored ? JSON.parse(likeStored) : {};
-    delete likeMap[id];
-    AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-    if (user) {
-      const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user?.id}`);
-      const likedMap = likedStored ? JSON.parse(likedStored) : {};
-      delete likedMap[id];
-      AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user.id}`, JSON.stringify(likedMap));
-    }
-
     await supabase.from('replies').delete().eq('id', id);
+    remove(id);
     fetchReplies();
   };
 
@@ -264,7 +254,6 @@ export default function ReplyDetailScreen() {
       if (postLikeCount !== undefined)
         likeEntries.push([parent.post_id, postLikeCount]);
       const fromServer = Object.fromEntries(likeEntries) as Record<string, number>;
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(fromServer));
       initialize([
         ...Object.entries(fromServer).map(([id, c]) => ({ id, like_count: c })),
       ]);
@@ -344,7 +333,6 @@ export default function ReplyDetailScreen() {
             ...storedLikes,
             ...Object.fromEntries(likeEntries),
           } as Record<string, number>;
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeCountsObj));
           initialize([
             { id: parent.post_id, like_count: storedLikes[parent.post_id] ?? 0 },
             ...cached.map((r: any) => ({ id: r.id, like_count: likeCountsObj[r.id] ?? 0 })),
@@ -354,7 +342,6 @@ export default function ReplyDetailScreen() {
         }
       } else {
         setReplyCounts(storedCounts);
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(storedLikes));
         initialize([{ id: parent.post_id, like_count: storedLikes[parent.post_id] ?? 0 }]);
       }
       if (user) {
@@ -485,10 +472,6 @@ export default function ReplyDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-    const likeMap = likeStored ? JSON.parse(likeStored) : {};
-    likeMap[newReply.id] = 0;
-    await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
     initialize([{ id: newReply.id, like_count: 0 }]);
     setReplyText('');
     setReplyImage(null);
@@ -542,13 +525,7 @@ export default function ReplyDetailScreen() {
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
           return counts;
         });
-        const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-        const likeMap = likeStored ? JSON.parse(likeStored) : {};
-        const temp = likeMap[newReply.id] ?? 0;
-        delete likeMap[newReply.id];
-        likeMap[data.id] = temp;
-        await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-        initialize([{ id: data.id, like_count: temp }]);
+        initialize([{ id: data.id, like_count: 0 }]);
 
       }
       fetchReplies();


### PR DESCRIPTION
## Summary
- remove direct LIKE_COUNT_KEY writes on screens
- clear post store entries on reply delete

## Testing
- `npx tsc -noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68445dfac76483229119c1dfb76fa042