### PR TITLE
Fix reply deletion cache clearing

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
 import { supabase } from './lib/supabase';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -248,7 +254,7 @@ export function AuthProvider({ children }) {
     }
   };
 
-  const fetchMyPosts = async () => {
+  const fetchMyPosts = useCallback(async () => {
     const id = user?.id;
     if (!id) {
       setMyPosts([]);
@@ -272,7 +278,7 @@ export function AuthProvider({ children }) {
       });
     }
 
-  };
+  }, [user]);
 
   const addPost = (post) => {
     setMyPosts((prev) => [post, ...prev]);

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -64,7 +64,7 @@ export default function PostCard({
       <View style={styles.post}>
         {isOwner && (
           <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
-            <Text style={{ color: 'white' }}>X</Text>
+            <Text style={styles.deleteText}>X</Text>
           </TouchableOpacity>
         )}
         <View style={styles.row}>
@@ -121,8 +121,9 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 6,
     top: 6,
-    padding: 4,
+    padding: 5,
   },
+  deleteText: { color: 'white', fontSize: 18 },
   postContent: { color: 'white' },
   username: { fontWeight: 'bold', color: 'white' },
   timestamp: { fontSize: 10, color: 'gray' },

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../../lib/supabase';
+import { getLikeCounts } from '../../lib/getLikeCounts';
 import { useAuth } from '../../AuthContext';
 import { usePostStore } from '../contexts/PostStoreContext';
 import { colors } from '../styles/colors';
@@ -49,7 +50,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const { user, profile, profileImageUri, bannerImageUri, addPost, updatePost } =
 
     useAuth() as any;
-  const { initialize, remove } = usePostStore();
+  const { initialize, mergeLiked, remove } = usePostStore();
   const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
@@ -62,16 +63,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
 
 
-  const confirmDeletePost = (id: string) => {
-    Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Delete',
-        style: 'destructive',
-        onPress: () => handleDeletePost(id),
-      },
-    ]);
-  };
+
 
   const handleDeletePost = async (id: string) => {
     setPosts(prev => {
@@ -225,7 +217,6 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
     if (!error && data) {
       const replyEntries = (data as any[]).map(p => [p.id, p.reply_count ?? 0]);
-      const likeEntries = (data as any[]).map(p => [p.id, p.like_count ?? 0]);
       const slice = (data as Post[]).slice(0, PAGE_SIZE);
 
       // Preserve any optimistic posts that are not yet returned from the server
@@ -253,9 +244,10 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(merged));
         return merged;
       });
-      const likeMap = Object.fromEntries(likeEntries);
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-      initialize(data.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 })));
+      const likeCounts = await getLikeCounts(slice.map(p => p.id));
+      initialize(
+        slice.map(p => ({ id: p.id, like_count: likeCounts[p.id] })),
+      );
 
 
       if (user) {
@@ -273,6 +265,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
             `${LIKED_KEY_PREFIX}${user.id}`,
             JSON.stringify(likedObj),
           );
+          mergeLiked(likedObj);
         }
 
       }
@@ -430,8 +423,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           setReplyCounts(Object.fromEntries(entries));
       const likeEntries = cached.map((p: any) => [p.id, p.like_count ?? 0]);
       const likeMap = Object.fromEntries(likeEntries);
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-      initialize(cached.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 })));
+      initialize(cached.map((p: any) => ({ id: p.id, like_count: p.like_count ?? 0 }))); 
 
 
         } catch (e) {
@@ -448,9 +440,14 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       }
       const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
       if (likeStored) {
-        // store counts for the like hook
         try {
-          JSON.parse(likeStored);
+          const parsed = JSON.parse(likeStored);
+          initialize(
+            Object.entries(parsed).map(([id, c]) => ({
+              id,
+              like_count: c as number,
+            })),
+          );
         } catch (e) {
           console.error('Failed to parse cached like counts', e);
         }
@@ -459,7 +456,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
         if (likedStored) {
           try {
-            JSON.parse(likedStored);
+            const map = JSON.parse(likedStored);
+            mergeLiked(map);
           } catch (e) {
             console.error('Failed to parse cached likes', e);
           }
@@ -487,7 +485,13 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
         if (likeStored) {
           try {
-            JSON.parse(likeStored);
+            const parsed = JSON.parse(likeStored);
+            initialize(
+              Object.entries(parsed).map(([id, c]) => ({
+                id,
+                like_count: c as number,
+              })),
+            );
           } catch (e) {
             console.error('Failed to parse cached like counts', e);
           }
@@ -496,7 +500,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
           if (likedStored) {
             try {
-              JSON.parse(likedStored);
+              const map = JSON.parse(likedStored);
+              mergeLiked(map);
             } catch (e) {
               console.error('Failed to parse cached likes', e);
             }
@@ -556,7 +561,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                       username: userName,
                     })
               }
-              onDelete={() => confirmDeletePost(item.id)}
+              onDelete={() => handleDeletePost(item.id)}
               onOpenReplies={() => openReplyModal(item.id)}
             />
           );

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -19,6 +19,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
 
 import { supabase } from '../../lib/supabase';
+import { getLikeCounts } from '../../lib/getLikeCounts';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 import { replyEvents } from '../replyEvents';
@@ -150,27 +151,8 @@ export default function PostDetailScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
       return counts;
     });
-    const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-    if (likeStored) {
-      try {
-        const map = JSON.parse(likeStored);
-        delete map[id];
-        await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
-      } catch {}
-    }
-    if (user) {
-      const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user?.id}`);
-      if (likedStored) {
-        try {
-          const map = JSON.parse(likedStored);
-          delete map[id];
-          await AsyncStorage.setItem(`${LIKED_KEY_PREFIX}${user.id}`, JSON.stringify(map));
-        } catch {}
-      }
-    }
-    remove(id);
-
     await supabase.from('replies').delete().eq('id', id);
+    remove(id);
     fetchReplies();
   };
 
@@ -203,7 +185,13 @@ export default function PostDetailScreen() {
         const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
         if (likeStored) {
           try {
-            JSON.parse(likeStored);
+            const parsed = JSON.parse(likeStored);
+            initialize(
+              Object.entries(parsed).map(([id, c]) => ({
+                id,
+                like_count: c as number,
+              })),
+            );
           } catch (e) {
             console.error('Failed to parse cached like counts', e);
           }
@@ -264,22 +252,9 @@ export default function PostDetailScreen() {
         AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
         return counts;
       });
-      const likeEntries = all.map(r => [r.id, r.like_count ?? 0]);
-      const { data: postLike } = await supabase
-        .from('posts')
-        .select('like_count')
-        .eq('id', post.id)
-        .single();
-
-      const postLikeCount = postLike ? postLike.like_count ?? 0 : post.like_count ?? 0;
-      likeEntries.push([post.id, postLikeCount]);
-
-      const counts = Object.fromEntries(likeEntries) as Record<string, number>;
-      AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(counts));
-      initialize([
-        { id: post.id, like_count: postLikeCount },
-        ...all.map(r => ({ id: r.id, like_count: r.like_count ?? 0 })),
-      ]);
+      const ids = [post.id, ...all.map(r => r.id)];
+      const likeCounts = await getLikeCounts(ids);
+      initialize(ids.map(id => ({ id, like_count: likeCounts[id] })));
 
 
       if (user) {
@@ -360,27 +335,34 @@ export default function PostDetailScreen() {
           setReplyCounts(counts);
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
 
-          const likeEntries = cached.map((r: any) => [r.id, r.like_count ?? 0]);
+          const likeEntries = cached.map((r: any) => [r.id, storedLikes[r.id] ?? r.like_count ?? 0]);
 
           likeEntries.push([post.id, storedLikes[post.id] ?? post.like_count ?? 0]);
           const likeCountsObj = {
             ...Object.fromEntries(likeEntries),
             ...storedLikes,
           } as Record<string, number>;
-          AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeCountsObj));
           initialize([
-            { id: post.id, like_count: storedLikes[post.id] ?? post.like_count ?? 0 },
-            ...cached.map((r: any) => ({ id: r.id, like_count: r.like_count ?? 0 })),
+            { id: post.id, like_count: likeCountsObj[post.id] ?? 0 },
+            ...cached.map((r: any) => ({ id: r.id, like_count: likeCountsObj[r.id] ?? 0 })),
           ]);
         } catch (e) {
           console.error('Failed to parse cached replies', e);
         }
       } else {
         setReplyCounts(storedCounts);
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(storedLikes));
-        initialize([
-          { id: post.id, like_count: storedLikes[post.id] ?? post.like_count ?? 0 },
-        ]);
+        const items = Object.keys(storedLikes).length
+          ? Object.entries(storedLikes).map(([id, c]) => ({
+              id,
+              like_count: c as number,
+            }))
+          : [
+              {
+                id: post.id,
+                like_count: storedLikes[post.id] ?? post.like_count ?? 0,
+              },
+            ];
+        initialize(items);
 
       }
 
@@ -457,10 +439,6 @@ export default function PostDetailScreen() {
     });
     initialize([{ id: newReply.id, like_count: 0 }]);
     replyEvents.emit('replyAdded', post.id);
-    const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-    const map = likeStored ? JSON.parse(likeStored) : {};
-    map[newReply.id] = 0;
-    AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
     setReplyText('');
     setReplyImage(null);
 
@@ -510,13 +488,7 @@ export default function PostDetailScreen() {
           AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
           return counts;
         });
-        const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-        const map = likeStored ? JSON.parse(likeStored) : {};
-        const temp = map[newReply.id] ?? 0;
-        delete map[newReply.id];
-        map[data.id] = temp;
-        AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(map));
-        initialize([{ id: data.id, like_count: temp }]);
+        initialize([{ id: data.id, like_count: 0 }]);
 
 
       }

--- a/lib/getLikeCounts.ts
+++ b/lib/getLikeCounts.ts
@@ -1,0 +1,20 @@
+import { supabase } from './supabase';
+
+export async function getLikeCounts(
+  ids: string[],
+  isReply: boolean = false,
+): Promise<Record<string, number | undefined>> {
+  const counts: Record<string, number | undefined> = {};
+  await Promise.all(
+    ids.map(async id => {
+      const { data, error, count } = await supabase
+        .from('likes')
+        .select('id', { count: 'exact', head: true })
+        .match(isReply ? { reply_id: id } : { post_id: id });
+      if (!error && typeof count === 'number') {
+        counts[id] = count;
+      }
+    }),
+  );
+  return counts;
+}

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -42,6 +42,10 @@ create policy "Users can insert posts" on public.posts
 create policy "Anyone can read posts" on public.posts
   for select using (true);
 
+-- Allow users to delete their own posts
+create policy "Users can delete their posts" on public.posts
+  for delete using (auth.uid() = user_id);
+
 -- Add the username column only if it doesn't exist (for older setups)
 alter table public.profiles add column if not exists image_url text;
 alter table public.posts add column if not exists username text;


### PR DESCRIPTION
## Summary
- clean up reply deletion code
- remove manual like state edits and rely on the post store after deletion
- restore instant delete button on home feed and enlarge the X icon

## Testing
- `npx tsc -noEmit` *(fails: cannot use JSX without the `--jsx` flag)*

------
https://chatgpt.com/codex/tasks/task_e_68445dfac76483229119c1dfb76fa042