### PR TITLE
Add delete confirmation dialogs

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -566,7 +566,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                       username: userName,
                     })
               }
-              onDelete={() => handleDeletePost(item.id)}
+              onDelete={() => confirmDeletePost(item.id)}
               onOpenReplies={() => openReplyModal(item.id)}
             />
           );

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -74,7 +74,7 @@ export default function PostDetailScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       {
         text: 'Delete',
         style: 'destructive',
@@ -105,7 +105,7 @@ export default function PostDetailScreen() {
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       {
         text: 'Delete',
         style: 'destructive',

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -105,7 +105,7 @@ export default function ProfileScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       { text: 'Delete', style: 'destructive', onPress: () => handleDeletePost(id) },
     ]);
   };

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -120,7 +120,7 @@ export default function ReplyDetailScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       {
         text: 'Delete',
         style: 'destructive',
@@ -139,7 +139,7 @@ export default function ReplyDetailScreen() {
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       {
         text: 'Delete',
         style: 'destructive',


### PR DESCRIPTION
## Summary
- ask for confirmation before deleting posts or replies
- use "Confirm" text instead of "Cancel" in alert dialogs
- wire up delete button on home screen to show confirmation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68458e26863083228f2631a70598129f