### PR TITLE
Keep profile feed synced with home deletions

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -17,7 +17,7 @@ export default function Navigator() {
   if (loading) return null;
 
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator screenOptions={{ headerShown: false, detachInactiveScreens: false }}>
       {user ? (
         <>
           <Stack.Screen name="Tabs" component={TopTabsNavigator} />

--- a/app/likeEvents.ts
+++ b/app/likeEvents.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'events';
+
+export const likeEvents = new EventEmitter();

--- a/app/postEvents.ts
+++ b/app/postEvents.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'events';
+
+export const postEvents = new EventEmitter();

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -25,6 +25,8 @@ import { useAuth } from '../../AuthContext';
 import { usePostStore } from '../contexts/PostStoreContext';
 import { colors } from '../styles/colors';
 import { replyEvents } from '../replyEvents';
+import { postEvents } from '../postEvents';
+import { likeEvents } from '../likeEvents';
 import PostCard, { Post } from '../components/PostCard';
 
 const STORAGE_KEY = 'cached_posts';
@@ -47,7 +49,7 @@ interface HomeScreenProps {
 const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   ({ hideInput }, ref) => {
     const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri, addPost, updatePost } =
+  const { user, profile, profileImageUri, bannerImageUri, addPost, updatePost, removePost } =
 
     useAuth() as any;
   const { initialize, mergeLiked, remove } = usePostStore();
@@ -80,8 +82,9 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
       return rest;
     });
-    remove(id);
     await supabase.from('posts').delete().eq('id', id);
+    remove(id);
+    await removePost(id);
   };
 
 
@@ -317,7 +320,13 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
 
     // Cache the new post for the profile screen as well
-    addPost({ id: newPost.id, content: text, created_at: newPost.created_at });
+    addPost({
+      id: newPost.id,
+      content: text,
+      created_at: newPost.created_at,
+      image_url: imageUri,
+      username: profile.name || profile.username,
+    });
 
     if (!hideInput) {
       setPostText('');
@@ -363,6 +372,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           id: data.id,
           content: data.content,
           created_at: data.created_at,
+          image_url: data.image_url,
+          username: data.username,
         });
         setReplyCounts(prev => {
           const { [newPost.id]: tempCount, ...rest } = prev;
@@ -414,6 +425,39 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     replyEvents.on('replyAdded', onReplyAdded);
     return () => {
       replyEvents.off('replyAdded', onReplyAdded);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onPostDeleted = (postId: string) => {
+      setPosts(prev => {
+        const updated = prev.filter(p => p.id !== postId);
+        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+      setReplyCounts(prev => {
+        const { [postId]: _omit, ...rest } = prev;
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
+        return rest;
+      });
+    };
+    postEvents.on('postDeleted', onPostDeleted);
+    return () => {
+      postEvents.off('postDeleted', onPostDeleted);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
+      setPosts(prev => {
+        const updated = prev.map(p => (p.id === id ? { ...p, like_count: count } : p));
+        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
     };
   }, []);
 
@@ -566,7 +610,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
                       username: userName,
                     })
               }
-              onDelete={() => handleDeletePost(item.id)}
+              onDelete={() => confirmDeletePost(item.id)}
               onOpenReplies={() => openReplyModal(item.id)}
             />
           );

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -24,6 +24,7 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 import { replyEvents } from '../replyEvents';
 import { usePostStore } from '../contexts/PostStoreContext';
+import { postEvents } from '../postEvents';
 import PostCard, { Post } from '../components/PostCard';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
@@ -57,7 +58,7 @@ interface Reply {
 export default function PostDetailScreen() {
   const route = useRoute<any>();
   const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri } = useAuth() as any;
+  const { user, profile, profileImageUri, bannerImageUri, removePost } = useAuth() as any;
   const { initialize, remove } = usePostStore();
   const post = route.params.post as Post;
   const fromProfile = route.params?.fromProfile ?? false;
@@ -74,7 +75,7 @@ export default function PostDetailScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       {
         text: 'Delete',
         style: 'destructive',
@@ -99,13 +100,14 @@ export default function PostDetailScreen() {
   const handleDeletePost = async (id: string) => {
     await supabase.from('posts').delete().eq('id', id);
     remove(id);
+    await removePost(id);
     navigation.goBack();
   };
 
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      { text: 'Confirm', style: 'cancel' },
       {
         text: 'Delete',
         style: 'destructive',

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -11,6 +11,10 @@ import {
   Dimensions,
   FlatList,
   Alert,
+  TextInput,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
@@ -24,9 +28,15 @@ import { colors } from '../styles/colors';
 import { supabase } from '../../lib/supabase';
 import { getLikeCounts } from '../../lib/getLikeCounts';
 import PostCard, { Post } from '../components/PostCard';
+import { replyEvents } from '../replyEvents';
+import { postEvents } from '../postEvents';
+import { likeEvents } from '../likeEvents';
+
+const CANCEL_ACTION = { text: 'Confirm', style: 'cancel' } as const;
 
 const STORAGE_KEY = 'cached_posts';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
+const REPLY_STORAGE_PREFIX = 'cached_replies_';
 
 
 
@@ -48,12 +58,17 @@ export default function ProfileScreen() {
     setBannerImageUri,
     myPosts: posts,
     fetchMyPosts,
+    removePost,
   } = useAuth() as any;
   const { initialize, remove } = usePostStore();
 
   const [myPosts, setMyPosts] = useState<Post[]>(posts ?? []);
 
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
+  const [replyModalVisible, setReplyModalVisible] = useState(false);
+  const [activePostId, setActivePostId] = useState<string | null>(null);
+  const [replyText, setReplyText] = useState('');
+  const [replyImage, setReplyImage] = useState<string | null>(null);
 
   const { followers, following } = useFollowCounts(profile?.id ?? null);
 
@@ -62,8 +77,13 @@ export default function ProfileScreen() {
       if (posts && posts.length) {
         const counts = await getLikeCounts(posts.map(p => p.id));
         initialize(posts.map(p => ({ id: p.id, like_count: counts[p.id] })));
-
-        setMyPosts(posts);
+        const seen = new Set<string>();
+        const unique = posts.filter(p => {
+          if (seen.has(p.id)) return false;
+          seen.add(p.id);
+          return true;
+        });
+        setMyPosts(unique);
       } else {
         setMyPosts([]);
       }
@@ -86,9 +106,58 @@ export default function ProfileScreen() {
     loadCounts();
   }, []);
 
+  useEffect(() => {
+    const onReplyAdded = (postId: string) => {
+      setReplyCounts(prev => {
+        const updated = { ...prev, [postId]: (prev[postId] || 0) + 1 };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+    };
+    replyEvents.on('replyAdded', onReplyAdded);
+    return () => {
+      replyEvents.off('replyAdded', onReplyAdded);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onPostDeleted = (postId: string) => {
+      setMyPosts(prev => {
+        const updated = prev.filter(p => p.id !== postId);
+        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+      setReplyCounts(prev => {
+        const { [postId]: _omit, ...rest } = prev;
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
+        return rest;
+      });
+    };
+    postEvents.on('postDeleted', onPostDeleted);
+    return () => {
+      postEvents.off('postDeleted', onPostDeleted);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
+      setMyPosts(prev => {
+        const updated = prev.map(p => (p.id === id ? { ...p, like_count: count } : p));
+        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, []);
+
   useFocusEffect(
     useCallback(() => {
-      fetchMyPosts();
+      if (!posts || posts.length === 0) {
+        fetchMyPosts();
+      }
       const syncCounts = async () => {
         const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
         if (stored) {
@@ -100,12 +169,12 @@ export default function ProfileScreen() {
         }
       };
       syncCounts();
-    }, [fetchMyPosts]),
+    }, [fetchMyPosts, posts?.length]),
   );
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      CANCEL_ACTION,
       { text: 'Delete', style: 'destructive', onPress: () => handleDeletePost(id) },
     ]);
   };
@@ -121,9 +190,117 @@ export default function ProfileScreen() {
       AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(rest));
       return rest;
     });
-    remove(id);
     await supabase.from('posts').delete().eq('id', id);
-    fetchMyPosts();
+    remove(id);
+    await removePost(id);
+  };
+
+  const openReplyModal = (postId: string) => {
+    setActivePostId(postId);
+    setReplyText('');
+    setReplyImage(null);
+    setReplyModalVisible(true);
+  };
+
+  const pickReplyImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setReplyImage(`data:image/jpeg;base64,${base64}`);
+    }
+  };
+
+  const handleReplySubmit = async () => {
+    if (!activePostId || (!replyText.trim() && !replyImage) || !profile) {
+      setReplyModalVisible(false);
+      return;
+    }
+
+    setReplyModalVisible(false);
+
+    const newReply = {
+      id: `temp-${Date.now()}`,
+      post_id: activePostId,
+      parent_id: null,
+      user_id: profile.id,
+      content: replyText,
+      image_url: replyImage ?? undefined,
+      created_at: new Date().toISOString(),
+      username: profile.name || profile.username,
+      reply_count: 0,
+      like_count: 0,
+      profiles: {
+        username: profile.username,
+        name: profile.name,
+        image_url: profileImageUri,
+        banner_url: bannerImageUri,
+      },
+    } as const;
+
+    const storageKey = `${REPLY_STORAGE_PREFIX}${activePostId}`;
+    try {
+      const stored = await AsyncStorage.getItem(storageKey);
+      const cached = stored ? JSON.parse(stored) : [];
+      const updated = [newReply, ...cached];
+      await AsyncStorage.setItem(storageKey, JSON.stringify(updated));
+    } catch (e) {
+      console.error('Failed to cache reply', e);
+    }
+
+    setReplyCounts(prev => {
+      const counts = { ...prev, [activePostId]: (prev[activePostId] || 0) + 1, [newReply.id]: 0 };
+      AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+      return counts;
+    });
+    initialize([{ id: newReply.id, like_count: 0 }]);
+
+    setReplyText('');
+    setReplyImage(null);
+
+    let { data, error } = await supabase
+      .from('replies')
+      .insert({
+        post_id: activePostId,
+        parent_id: null,
+        user_id: profile.id,
+        content: replyText,
+        image_url: replyImage,
+        username: profile.name || profile.username,
+      })
+      .select()
+      .single();
+    if (error?.code === 'PGRST204') {
+      error = null;
+    }
+
+    if (!error && data) {
+      try {
+        const stored = await AsyncStorage.getItem(storageKey);
+        const cached = stored ? JSON.parse(stored) : [];
+        const updated = cached.map((r: any) =>
+          r.id === newReply.id ? { ...r, id: data.id, created_at: data.created_at } : r,
+        );
+        await AsyncStorage.setItem(storageKey, JSON.stringify(updated));
+      } catch (e) {
+        console.error('Failed to update cached reply', e);
+      }
+      setReplyCounts(prev => {
+        const temp = prev[newReply.id] ?? 0;
+        const { [newReply.id]: _omit, ...rest } = prev;
+        const counts = { ...rest, [data.id]: temp };
+        AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(counts));
+        return counts;
+      });
+      initialize([{ id: data.id, like_count: 0 }]);
+      replyEvents.emit('replyAdded', activePostId);
+    } else if (error) {
+      console.error('Reply failed', error.message);
+    }
   };
 
 
@@ -217,32 +394,55 @@ export default function ProfileScreen() {
         <Text style={styles.uploadText}>Upload Banner</Text>
       </TouchableOpacity>
 
-      {/* Removed duplicate post list */}
     </View>
   );
 
   return (
-    <FlatList
-      style={styles.container}
-      contentContainerStyle={styles.contentContainer}
-      data={myPosts}
-
-      ListHeaderComponent={renderHeader}
-      keyExtractor={item => item.id}
-      renderItem={({ item }) => (
-        <PostCard
-          post={item as Post}
-          isOwner={true}
-          avatarUri={profileImageUri ?? undefined}
-          bannerUrl={bannerImageUri ?? undefined}
-          replyCount={replyCounts[item.id] ?? item.reply_count ?? 0}
-          onPress={() => navigation.navigate('PostDetail', { post: item })}
-          onProfilePress={() => navigation.navigate('Profile')}
-          onDelete={() => confirmDeletePost(item.id)}
-          onOpenReplies={() => {}}
-        />
-      )}
-    />
+    <View style={{ flex: 1 }}>
+      <FlatList
+        style={styles.container}
+        contentContainerStyle={styles.contentContainer}
+        data={myPosts}
+        ListHeaderComponent={renderHeader}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <PostCard
+            post={item as Post}
+            isOwner={true}
+            avatarUri={profileImageUri ?? undefined}
+            bannerUrl={bannerImageUri ?? undefined}
+            replyCount={replyCounts[item.id] ?? item.reply_count ?? 0}
+            onPress={() => navigation.navigate('PostDetail', { post: item })}
+            onProfilePress={() => navigation.navigate('Profile')}
+            onDelete={() => confirmDeletePost(item.id)}
+            onOpenReplies={() => openReplyModal(item.id)}
+          />
+        )}
+      />
+      <Modal visible={replyModalVisible} animationType="slide" transparent>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.modalOverlay}
+        >
+          <View style={styles.modalContent}>
+            <TextInput
+              placeholder="Write a reply"
+              value={replyText}
+              onChangeText={setReplyText}
+              style={styles.input}
+              multiline
+            />
+            {replyImage && (
+              <Image source={{ uri: replyImage }} style={styles.preview} />
+            )}
+            <View style={styles.buttonRow}>
+              <Button title="Add Image" onPress={pickReplyImage} />
+              <Button title="Post" onPress={handleReplySubmit} />
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
   );
 }
 
@@ -301,6 +501,32 @@ const styles = StyleSheet.create({
   statsText: { color: 'white', marginRight: 15 },
   headerContainer: {
     padding: 20,
+  },
+  input: {
+    backgroundColor: 'white',
+    padding: 10,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: colors.background,
+    padding: 20,
+  },
+  preview: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
   },
 
 

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -25,6 +25,9 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 import { usePostStore } from '../contexts/PostStoreContext';
 import useLike from '../hooks/useLike';
+import { postEvents } from '../postEvents';
+
+const CANCEL_ACTION = { text: 'Confirm', style: 'cancel' } as const;
 
 const CHILD_PREFIX = 'cached_child_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -101,7 +104,7 @@ function LikeInfo({ id, isPost = false }: { id: string; isPost?: boolean }) {
 export default function ReplyDetailScreen() {
   const route = useRoute<any>();
   const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri } = useAuth() as any;
+  const { user, profile, profileImageUri, bannerImageUri, removePost } = useAuth() as any;
   const { initialize, remove } = usePostStore();
   const parent = route.params.reply as Reply;
   const originalPost = route.params.originalPost as Post | undefined;
@@ -120,7 +123,7 @@ export default function ReplyDetailScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      CANCEL_ACTION,
       {
         text: 'Delete',
         style: 'destructive',
@@ -131,6 +134,8 @@ export default function ReplyDetailScreen() {
 
   const handleDeletePost = async (id: string) => {
     await supabase.from('posts').delete().eq('id', id);
+    remove(id);
+    await removePost(id);
     navigation.goBack();
   };
 
@@ -139,7 +144,7 @@ export default function ReplyDetailScreen() {
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Cancel', style: 'cancel' },
+      CANCEL_ACTION,
       {
         text: 'Delete',
         style: 'destructive',

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -1,11 +1,26 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Image, Button, Dimensions, ActivityIndicator, FlatList, TouchableOpacity } from 'react-native';
-import { useRoute, useNavigation } from '@react-navigation/native';
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  Button,
+  Dimensions,
+  ActivityIndicator,
+  FlatList,
+  TouchableOpacity,
+} from 'react-native';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
 import { useFollowCounts } from '../hooks/useFollowCounts';
 import { useAuth } from '../../AuthContext';
 import FollowButton from '../components/FollowButton';
+import PostCard, { Post } from '../components/PostCard';
+import { usePostStore } from '../contexts/PostStoreContext';
+import { likeEvents } from '../likeEvents';
+import { postEvents } from '../postEvents';
+import { getLikeCounts } from '../../lib/getLikeCounts';
 
 
 interface Profile {
@@ -44,6 +59,9 @@ export default function UserProfileScreen() {
       name: string | null;
       avatar_url: string | null;
     }[]>([]);
+
+  const [posts, setPosts] = useState<Post[]>([]);
+  const { initialize, remove } = usePostStore();
 
   const { user } = useAuth() as any;
 
@@ -96,6 +114,55 @@ export default function UserProfileScreen() {
     };
     fetchProfile();
   }, [userId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const loadPosts = async () => {
+        const { data, error } = await supabase
+          .from('posts')
+          .select(
+            'id, content, image_url, user_id, created_at, reply_count, like_count, username, profiles(username, name, image_url, banner_url)'
+          )
+          .eq('user_id', userId)
+          .order('created_at', { ascending: false });
+
+        if (!error && data) {
+          const seen = new Set<string>();
+          const unique = (data as Post[]).filter(p => {
+            if (seen.has(p.id)) return false;
+            seen.add(p.id);
+            return true;
+          });
+          setPosts(unique);
+          const counts = await getLikeCounts(unique.map(p => p.id));
+          initialize(unique.map(p => ({ id: p.id, like_count: counts[p.id] })));
+        } else if (error) {
+          console.error('Failed to fetch posts', error);
+        }
+      };
+      loadPosts();
+    }, [userId, initialize])
+  );
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
+      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onPostDeleted = (postId: string) => {
+      setPosts(prev => prev.filter(p => p.id !== postId));
+    };
+    postEvents.on('postDeleted', onPostDeleted);
+    return () => {
+      postEvents.off('postDeleted', onPostDeleted);
+    };
+  }, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -328,6 +395,25 @@ export default function UserProfileScreen() {
           <Text style={styles.statsText}>{following ?? 0} Following</Text>
         </TouchableOpacity>
       </View>
+
+      <Text style={styles.sectionTitle}>Posts</Text>
+      <FlatList
+        data={posts}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <PostCard
+            post={item as Post}
+            isOwner={false}
+            avatarUri={profile.image_url || avatarUrl || undefined}
+            bannerUrl={item.profiles?.banner_url || bannerUrl || undefined}
+            replyCount={item.reply_count ?? 0}
+            onPress={() => navigation.navigate('PostDetail', { post: item })}
+            onProfilePress={() => {}}
+            onDelete={() => {}}
+            onOpenReplies={() => navigation.navigate('PostDetail', { post: item })}
+          />
+        )}
+      />
 
       <Text style={styles.sectionTitle}>Following</Text>
       <FlatList


### PR DESCRIPTION
## Summary
- avoid refetching profile posts when local store already contains them

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68458e26863083228f2631a70598129f