### PR TITLE
Add global confirm action

### DIFF
--- a/app/constants/ui.ts
+++ b/app/constants/ui.ts
@@ -1,0 +1,1 @@
+export const CONFIRM_ACTION = { text: 'Confirm', style: 'cancel' } as const;

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -27,6 +27,7 @@ import { colors } from '../styles/colors';
 import { replyEvents } from '../replyEvents';
 import { postEvents } from '../postEvents';
 import { likeEvents } from '../likeEvents';
+import { CONFIRM_ACTION } from '../constants/ui';
 
 import PostCard, { Post } from '../components/PostCard';
 
@@ -66,7 +67,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
   const confirmDeletePost = (id: string) => {
     Alert.alert("Delete Post", "Are you sure you want to delete this post?", [
-      { text: "Cancel", style: "cancel" },
+      CONFIRM_ACTION,
       { text: "Delete", style: "destructive", onPress: () => handleDeletePost(id) }
     ]);
   };

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -26,6 +26,7 @@ import { replyEvents } from '../replyEvents';
 import { usePostStore } from '../contexts/PostStoreContext';
 import { postEvents } from '../postEvents';
 import PostCard, { Post } from '../components/PostCard';
+import { CONFIRM_ACTION } from '../constants/ui';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -75,7 +76,7 @@ export default function PostDetailScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Confirm', style: 'cancel' },
+      CONFIRM_ACTION,
       {
         text: 'Delete',
         style: 'destructive',
@@ -108,7 +109,7 @@ export default function PostDetailScreen() {
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      { text: 'Confirm', style: 'cancel' },
+      CONFIRM_ACTION,
       {
         text: 'Delete',
         style: 'destructive',

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -31,8 +31,7 @@ import PostCard, { Post } from '../components/PostCard';
 import { replyEvents } from '../replyEvents';
 import { postEvents } from '../postEvents';
 import { likeEvents } from '../likeEvents';
-
-const CANCEL_ACTION = { text: 'Confirm', style: 'cancel' } as const;
+import { CONFIRM_ACTION } from '../constants/ui';
 
 
 const STORAGE_KEY = 'cached_posts';
@@ -181,7 +180,7 @@ export default function ProfileScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      CANCEL_ACTION,
+      CONFIRM_ACTION,
 
       { text: 'Delete', style: 'destructive', onPress: () => handleDeletePost(id) },
     ]);

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -26,8 +26,7 @@ import { colors } from '../styles/colors';
 import { usePostStore } from '../contexts/PostStoreContext';
 import useLike from '../hooks/useLike';
 import { postEvents } from '../postEvents';
-
-const CANCEL_ACTION = { text: 'Confirm', style: 'cancel' } as const;
+import { CONFIRM_ACTION } from '../constants/ui';
 
 
 const CHILD_PREFIX = 'cached_child_replies_';
@@ -124,7 +123,7 @@ export default function ReplyDetailScreen() {
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      CANCEL_ACTION,
+      CONFIRM_ACTION,
 
       {
         text: 'Delete',
@@ -149,7 +148,7 @@ export default function ReplyDetailScreen() {
 
   const confirmDeleteReply = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
-      CANCEL_ACTION,
+      CONFIRM_ACTION,
 
       {
         text: 'Delete',


### PR DESCRIPTION
## Summary
- centralize confirm button style in constants
- use `CONFIRM_ACTION` across delete confirmation dialogs in various screens

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise', missing types)*
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68466c52bff08322a9f8e7744b3cf794