### PR TITLE
Always refresh posts on Profile focus

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -161,9 +161,7 @@ export default function ProfileScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      if (!posts || posts.length === 0) {
-        fetchMyPosts();
-      }
+      fetchMyPosts();
       const syncCounts = async () => {
         const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
         if (stored) {
@@ -175,7 +173,7 @@ export default function ProfileScreen() {
         }
       };
       syncCounts();
-    }, [fetchMyPosts, posts?.length]),
+    }, [fetchMyPosts]),
   );
 
   const confirmDeletePost = (id: string) => {


### PR DESCRIPTION
## Summary
- trigger `fetchMyPosts()` whenever the Profile screen gains focus

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846726273988322ab368a5f555eee3e