### PR TITLE
Ensure ProfileScreen stays mounted

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -132,12 +132,12 @@ export function AuthProvider({ children }) {
   }, [user]);
 
   useEffect(() => {
-    const onLikeChanged = ({ id, count }) => {
+    const onLikeChanged = ({ id, count, liked }) => {
       setMyPosts(prev => {
         const found = prev.find(p => p.id === id);
         if (!found) return prev;
         const updated = prev.map(p =>
-          p.id === id ? { ...p, like_count: count } : p,
+          p.id === id ? { ...p, like_count: count, liked } : p,
         );
         AsyncStorage.setItem('cached_posts', JSON.stringify(updated));
         return updated;

--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -23,7 +23,11 @@ export default function Navigator() {
           <Stack.Screen name="Tabs" component={TopTabsNavigator} />
           <Stack.Screen name="PostDetail" component={PostDetailScreen} />
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
-          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen
+            name="Profile"
+            component={ProfileScreen}
+            options={{ unmountOnBlur: false }}
+          />
           <Stack.Screen name="UserProfile" component={UserProfileScreen} />
           <Stack.Screen name="FollowList" component={FollowListScreen} />
         </>

--- a/app/constants/ui.ts
+++ b/app/constants/ui.ts
@@ -1,1 +1,1 @@
-export const CONFIRM_ACTION = { text: 'Confirm', style: 'cancel' } as const;
+export const CONFIRM_ACTION = { text: 'Cancel', style: 'cancel' } as const;

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -85,10 +85,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       return rest;
     });
     remove(id);
-    await removePost(id);
-
     await supabase.from('posts').delete().eq('id', id);
-    remove(id);
     await removePost(id);
   };
 

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -146,9 +146,9 @@ export default function ProfileScreen() {
   }, []);
 
   useEffect(() => {
-    const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
+    const onLikeChanged = ({ id, count, liked }: { id: string; count: number; liked: boolean }) => {
       setMyPosts(prev => {
-        const updated = prev.map(p => (p.id === id ? { ...p, like_count: count } : p));
+        const updated = prev.map(p => (p.id === id ? { ...p, like_count: count, liked } : p));
         AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
         return updated;
       });
@@ -196,8 +196,8 @@ export default function ProfileScreen() {
       return rest;
     });
     remove(id);
-    await removePost(id);
     await supabase.from('posts').delete().eq('id', id);
+    await removePost(id);
 
   };
 


### PR DESCRIPTION
## Summary
- keep the Profile screen mounted after first load so it receives `postDeleted` and `likeChanged` events
- sync likes across screens by persisting liked state in the user's posts
- update the deletion confirmation button text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684677cad3908322bbb8b34bcdc2103e