### PR TITLE
Move post event listeners to context

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -23,11 +23,7 @@ export default function Navigator() {
           <Stack.Screen name="Tabs" component={TopTabsNavigator} />
           <Stack.Screen name="PostDetail" component={PostDetailScreen} />
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
-          <Stack.Screen
-            name="Profile"
-            component={ProfileScreen}
-            options={{ unmountOnBlur: false }}
-          />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="UserProfile" component={UserProfileScreen} />
           <Stack.Screen name="FollowList" component={FollowListScreen} />
         </>


### PR DESCRIPTION
## Summary
- remove `unmountOnBlur` from the Profile screen stack
- watch `likeChanged` and `postDeleted` events in `AuthContext`
- simplify `ProfileScreen` to rely on context for `myPosts`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68468ad06da8832299cca88ed26ba69f