### PR TITLE
Keep profile posts up to date

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -290,8 +290,17 @@ export function AuthProvider({ children }) {
       .order('created_at', { ascending: false });
     if (!error && data) {
       setMyPosts(prev => {
+        const prevMap = Object.fromEntries(prev.map(p => [p.id, p]));
         const temps = prev.filter(p => String(p.id).startsWith('temp-'));
-        const merged = [...temps, ...data];
+        const merged = [
+          ...temps,
+          ...data.map(p => {
+            const existing = prevMap[p.id];
+            return existing
+              ? { ...p, like_count: existing.like_count, liked: existing.liked }
+              : p;
+          }),
+        ];
         const seen = new Set();
         return merged.filter(p => {
           if (seen.has(p.id)) return false;

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -55,7 +55,6 @@ export default function ProfileScreen() {
     bannerImageUri,
     setBannerImageUri,
     myPosts,
-    fetchMyPosts,
     removePost,
   } = useAuth() as any;
   const { initialize, remove, posts: storePosts } = usePostStore();
@@ -112,7 +111,6 @@ export default function ProfileScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      fetchMyPosts();
       const syncCounts = async () => {
         const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
         if (stored) {
@@ -124,7 +122,7 @@ export default function ProfileScreen() {
         }
       };
       syncCounts();
-    }, [fetchMyPosts]),
+    }, []),
   );
 
   const confirmDeletePost = (id: string) => {


### PR DESCRIPTION
## Summary
- preserve local like information when refreshing profile posts
- stop reloading profile posts every time profile screen focuses

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684693db96cc8322823a39e7e9654440