### PR TITLE
Fix post store reload on session refresh

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -257,6 +257,11 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       initialize(
         slice.map(p => ({ id: p.id, like_count: likeCounts[p.id] })),
       );
+      slice.forEach(p => {
+        if (user && p.user_id === user.id) {
+          updatePost(p.id, { like_count: likeCounts[p.id] });
+        }
+      });
 
 
 

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -55,7 +55,6 @@ export default function ProfileScreen() {
     bannerImageUri,
     setBannerImageUri,
     myPosts,
-    fetchMyPosts,
     removePost,
   } = useAuth() as any;
   const { initialize, remove, posts: storePosts } = usePostStore();
@@ -112,7 +111,6 @@ export default function ProfileScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      fetchMyPosts();
       const syncCounts = async () => {
         const stored = await AsyncStorage.getItem(COUNT_STORAGE_KEY);
         if (stored) {
@@ -124,7 +122,7 @@ export default function ProfileScreen() {
         }
       };
       syncCounts();
-    }, [fetchMyPosts]),
+    }, []),
   );
 
   const confirmDeletePost = (id: string) => {


### PR DESCRIPTION
## Summary
- don't reload cached posts when the same user session refreshes

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684693db96cc8322823a39e7e9654440