### PR TITLE
sync like counts between screens

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -29,6 +29,7 @@ import { supabase } from '../../lib/supabase';
 import { getLikeCounts } from '../../lib/getLikeCounts';
 import PostCard, { Post } from '../components/PostCard';
 import { replyEvents } from '../replyEvents';
+import { likeEvents } from '../likeEvents';
 
 import { CONFIRM_ACTION } from '../constants/ui';
 
@@ -56,6 +57,7 @@ export default function ProfileScreen() {
     setBannerImageUri,
     myPosts,
     removePost,
+    updatePost,
   } = useAuth() as any;
   const { initialize, remove, posts: storePosts } = usePostStore();
 
@@ -107,6 +109,16 @@ export default function ProfileScreen() {
       replyEvents.off('replyAdded', onReplyAdded);
     };
   }, []);
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count, liked }: { id: string; count: number; liked: boolean }) => {
+      updatePost(id, { like_count: count, liked });
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, [updatePost]);
 
 
 


### PR DESCRIPTION
## Summary
- listen for `likeChanged` events in `ProfileScreen`
- update profile posts when likes change

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846c14218b48322be490a5fc912e105