### PR TITLE
Sync profile replies with global updates

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -10,6 +10,7 @@ import { supabase } from './lib/supabase';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { postEvents } from './app/postEvents';
 import { likeEvents } from './app/likeEvents';
+import { replyEvents } from './app/replyEvents';
 
 
 const AuthContext = createContext();
@@ -150,6 +151,26 @@ export function AuthProvider({ children }) {
     likeEvents.on('likeChanged', onLikeChanged);
     return () => {
       likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onReplyAdded = (postId) => {
+      setMyPosts(prev => {
+        const found = prev.find(p => p.id === postId);
+        if (!found) return prev;
+        const updated = prev.map(p =>
+          p.id === postId
+            ? { ...p, reply_count: (p.reply_count ?? 0) + 1 }
+            : p,
+        );
+        AsyncStorage.setItem('cached_posts', JSON.stringify(updated));
+        return updated;
+      });
+    };
+    replyEvents.on('replyAdded', onReplyAdded);
+    return () => {
+      replyEvents.off('replyAdded', onReplyAdded);
     };
   }, []);
 

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -29,6 +29,7 @@ import { supabase } from '../../lib/supabase';
 import { getLikeCounts } from '../../lib/getLikeCounts';
 import PostCard, { Post } from '../components/PostCard';
 import { replyEvents } from '../replyEvents';
+import { likeEvents } from '../likeEvents';
 
 import { CONFIRM_ACTION } from '../constants/ui';
 
@@ -56,6 +57,7 @@ export default function ProfileScreen() {
     setBannerImageUri,
     myPosts,
     removePost,
+    updatePost,
   } = useAuth() as any;
   const { initialize, remove, posts: storePosts } = usePostStore();
 
@@ -107,6 +109,16 @@ export default function ProfileScreen() {
       replyEvents.off('replyAdded', onReplyAdded);
     };
   }, []);
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count, liked }: { id: string; count: number; liked: boolean }) => {
+      updatePost(id, { like_count: count, liked });
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, [updatePost]);
 
 
 


### PR DESCRIPTION
## Summary
- watch for `replyAdded` events in `AuthContext`
- update cached posts so `ProfileScreen` reflects new replies

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846c14218b48322be490a5fc912e105