### PR TITLE
Add types to AuthContext

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -12,7 +12,7 @@ import { useAuth } from './AuthContext';
 const Stack = createNativeStackNavigator();
 
 export default function Navigator() {
-  const { user, loading } = useAuth();
+  const { user, loading } = useAuth()!;
 
   if (loading) return null;
 

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -80,7 +80,7 @@ function HeaderTabBar(
 }
 
 export default function TopTabsNavigator() {
-  const { profile, user, signOut } = useAuth() as any;
+  const { profile, user, signOut } = useAuth()!;
   
 
   const insets = useSafeAreaInsets();

--- a/app/components/FollowButton.tsx
+++ b/app/components/FollowButton.tsx
@@ -10,7 +10,7 @@ interface FollowButtonProps {
 
 export default function FollowButton({ targetUserId, onToggle }: FollowButtonProps) {
 
-  const { user } = useAuth() as any;
+  const { user } = useAuth()!;
   const [following, setFollowing] = useState<boolean | null>(null);
 
   useEffect(() => {

--- a/app/contexts/PostStoreContext.tsx
+++ b/app/contexts/PostStoreContext.tsx
@@ -38,7 +38,7 @@ const PostStoreContext = createContext<PostStore | undefined>(undefined);
 export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const { user, updatePost } = useAuth() as any;
+  const { user, updatePost } = useAuth()!;
   const [posts, setPosts] = useState<Record<string, PostState>>({});
   const lastLoadedUserIdRef = useRef<string | null>(null);
 

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -51,9 +51,15 @@ interface HomeScreenProps {
 const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   ({ hideInput }, ref) => {
     const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri, addPost, updatePost, removePost } =
-
-    useAuth() as any;
+    const {
+      user,
+      profile,
+      profileImageUri,
+      bannerImageUri,
+      addPost,
+      updatePost,
+      removePost,
+    } = useAuth()!;
   const { initialize, mergeLiked, remove } = usePostStore();
   const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -59,7 +59,13 @@ interface Reply {
 export default function PostDetailScreen() {
   const route = useRoute<any>();
   const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri, removePost } = useAuth() as any;
+  const {
+    user,
+    profile,
+    profileImageUri,
+    bannerImageUri,
+    removePost,
+  } = useAuth()!;
   const { initialize, remove } = usePostStore();
   const post = route.params.post as Post;
   const fromProfile = route.params?.fromProfile ?? false;

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -58,7 +58,7 @@ export default function ProfileScreen() {
     myPosts,
     removePost,
     updatePost,
-  } = useAuth() as any;
+  } = useAuth()!;
   const { initialize, remove, posts: storePosts } = usePostStore();
 
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -104,7 +104,13 @@ function LikeInfo({ id, isPost = false }: { id: string; isPost?: boolean }) {
 export default function ReplyDetailScreen() {
   const route = useRoute<any>();
   const navigation = useNavigation<any>();
-  const { user, profile, profileImageUri, bannerImageUri, removePost } = useAuth() as any;
+  const {
+    user,
+    profile,
+    profileImageUri,
+    bannerImageUri,
+    removePost,
+  } = useAuth()!;
   const { initialize, remove } = usePostStore();
   const parent = route.params.reply as Reply;
   const originalPost = route.params.originalPost as Post | undefined;

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -64,7 +64,7 @@ export default function UserProfileScreen() {
   const [posts, setPosts] = useState<Post[]>([]);
   const { initialize, remove } = usePostStore();
 
-  const { user } = useAuth() as any;
+  const { user } = useAuth()!;
 
   const name = profile?.name ?? initialName ?? null;
   const username = profile?.username ?? initialUsername ?? null;


### PR DESCRIPTION
## Summary
- convert `AuthContext` to TypeScript and add a typed context value interface
- update `createContext` generic
- use the typed hook across screens and contexts

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6846c838da7c8322803af1c916f89130