### PR TITLE
Keep ProfileScreen always mounted

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -10,6 +10,7 @@ import { supabase } from './lib/supabase';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { postEvents } from './app/postEvents';
 import { likeEvents } from './app/likeEvents';
+import { replyEvents } from './app/replyEvents';
 
 
 const AuthContext = createContext();
@@ -150,6 +151,26 @@ export function AuthProvider({ children }) {
     likeEvents.on('likeChanged', onLikeChanged);
     return () => {
       likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onReplyAdded = (postId) => {
+      setMyPosts(prev => {
+        const found = prev.find(p => p.id === postId);
+        if (!found) return prev;
+        const updated = prev.map(p =>
+          p.id === postId
+            ? { ...p, reply_count: (p.reply_count ?? 0) + 1 }
+            : p,
+        );
+        AsyncStorage.setItem('cached_posts', JSON.stringify(updated));
+        return updated;
+      });
+    };
+    replyEvents.on('replyAdded', onReplyAdded);
+    return () => {
+      replyEvents.off('replyAdded', onReplyAdded);
     };
   }, []);
 

--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -4,7 +4,6 @@ import AuthPage from './AuthPage';
 import TopTabsNavigator from './app/TopTabsNavigator';
 import PostDetailScreen from './app/screens/PostDetailScreen';
 import ReplyDetailScreen from './app/screens/ReplyDetailScreen';
-import ProfileScreen from './app/screens/ProfileScreen';
 import UserProfileScreen from './app/screens/UserProfileScreen';
 import FollowListScreen from './app/screens/FollowListScreen';
 import { useAuth } from './AuthContext';
@@ -23,7 +22,6 @@ export default function Navigator() {
           <Stack.Screen name="Tabs" component={TopTabsNavigator} />
           <Stack.Screen name="PostDetail" component={PostDetailScreen} />
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
-          <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="UserProfile" component={UserProfileScreen} />
           <Stack.Screen name="FollowList" component={FollowListScreen} />
         </>

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -28,6 +28,7 @@ import {
 import { useAuth } from '../AuthContext';
 import { useNavigation } from '@react-navigation/native';
 import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
+import ProfileScreen from './screens/ProfileScreen';
 import { supabase } from '../lib/supabase';
 import { colors } from './styles/colors';
 import * as ImagePicker from 'expo-image-picker';
@@ -206,6 +207,11 @@ export default function TopTabsNavigator() {
       >
         <Tab.Screen name="For you" component={ForYouScreen} />
         <Tab.Screen name="Following" component={FollowingScreen} />
+        <Tab.Screen
+          name="Profile"
+          component={ProfileScreen}
+          options={{ unmountOnBlur: false }}
+        />
         </Tab.Navigator>
 
         <TouchableOpacity
@@ -247,7 +253,7 @@ export default function TopTabsNavigator() {
         <TouchableOpacity
           onPress={() => {
             closeDrawer();
-            navigation.navigate('Profile');
+            navigation.navigate('Tabs', { screen: 'Profile' });
           }}
         >
 

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -610,7 +610,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
               onPress={() => navigation.navigate('PostDetail', { post: item })}
               onProfilePress={() =>
                 isMe
-                  ? navigation.navigate('Profile')
+                  ? navigation.navigate('Tabs', { screen: 'Profile' })
                   : navigation.navigate('UserProfile', {
                       userId: item.user_id,
                       avatarUrl: avatarUri,

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -519,7 +519,7 @@ export default function PostDetailScreen() {
       <View style={styles.backButton}>
         <Button
           title="Return"
-          onPress={() => (fromProfile ? navigation.navigate('Profile') : navigation.goBack())}
+          onPress={() => (fromProfile ? navigation.navigate('Tabs', { screen: 'Profile' }) : navigation.goBack())}
         />
       </View>
       <FlatList
@@ -535,7 +535,7 @@ export default function PostDetailScreen() {
             onPress={() => {}}
             onProfilePress={() =>
               user?.id === post.user_id
-                ? navigation.navigate('Profile')
+                ? navigation.navigate('Tabs', { screen: 'Profile' })
                 : navigation.navigate('UserProfile', {
                     userId: post.user_id,
                     avatarUrl: post.profiles?.image_url,
@@ -574,7 +574,7 @@ export default function PostDetailScreen() {
               }
               onProfilePress={() =>
                 isMe
-                  ? navigation.navigate('Profile')
+                  ? navigation.navigate('Tabs', { screen: 'Profile' })
                   : navigation.navigate('UserProfile', {
                       userId: item.user_id,
                       avatarUrl: avatarUri,

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -29,6 +29,7 @@ import { supabase } from '../../lib/supabase';
 import { getLikeCounts } from '../../lib/getLikeCounts';
 import PostCard, { Post } from '../components/PostCard';
 import { replyEvents } from '../replyEvents';
+import { likeEvents } from '../likeEvents';
 
 import { CONFIRM_ACTION } from '../constants/ui';
 
@@ -56,6 +57,7 @@ export default function ProfileScreen() {
     setBannerImageUri,
     myPosts,
     removePost,
+    updatePost,
   } = useAuth() as any;
   const { initialize, remove, posts: storePosts } = usePostStore();
 
@@ -107,6 +109,16 @@ export default function ProfileScreen() {
       replyEvents.off('replyAdded', onReplyAdded);
     };
   }, []);
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count, liked }: { id: string; count: number; liked: boolean }) => {
+      updatePost(id, { like_count: count, liked });
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+    };
+  }, [updatePost]);
 
 
 
@@ -350,7 +362,7 @@ export default function ProfileScreen() {
             bannerUrl={bannerImageUri ?? undefined}
             replyCount={replyCounts[item.id] ?? item.reply_count ?? 0}
             onPress={() => navigation.navigate('PostDetail', { post: item })}
-            onProfilePress={() => navigation.navigate('Profile')}
+            onProfilePress={() => navigation.navigate('Tabs', { screen: 'Profile' })}
             onDelete={() => confirmDeletePost(item.id)}
             onOpenReplies={() => openReplyModal(item.id)}
           />

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -579,7 +579,7 @@ export default function ReplyDetailScreen() {
                   <TouchableOpacity
                     onPress={() =>
                       user?.id === originalPost.user_id
-                        ? navigation.navigate('Profile')
+                        ? navigation.navigate('Tabs', { screen: 'Profile' })
                         : navigation.navigate('UserProfile', {
                             userId: originalPost.user_id,
                             avatarUrl: originalPost.profiles?.image_url,
@@ -648,7 +648,7 @@ export default function ReplyDetailScreen() {
                     <TouchableOpacity
                       onPress={() =>
                         isMe
-                          ? navigation.navigate('Profile')
+                          ? navigation.navigate('Tabs', { screen: 'Profile' })
                           : navigation.navigate('UserProfile', {
                               userId: a.user_id,
                               avatarUrl: avatarUri,
@@ -709,7 +709,7 @@ export default function ReplyDetailScreen() {
                 <TouchableOpacity
                   onPress={() =>
                     user?.id === parent.user_id
-                      ? navigation.navigate('Profile')
+                      ? navigation.navigate('Tabs', { screen: 'Profile' })
                       : navigation.navigate('UserProfile', {
                           userId: parent.user_id,
                           avatarUrl: parent.profiles?.image_url,
@@ -789,7 +789,7 @@ export default function ReplyDetailScreen() {
                   <TouchableOpacity
                     onPress={() =>
                       isMe
-                        ? navigation.navigate('Profile')
+                        ? navigation.navigate('Tabs', { screen: 'Profile' })
                         : navigation.navigate('UserProfile', {
                             userId: item.user_id,
                             avatarUrl: avatarUri,


### PR DESCRIPTION
## Summary
- remove stack registration for `Profile` screen
- add `Profile` tab with `unmountOnBlur: false` to keep component mounted
- update navigation calls to reach the tabbed profile

## Testing
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846c14218b48322be490a5fc912e105