### PR TITLE
Enable avatar taps to open OtherUserProfile

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -6,6 +6,7 @@ import PostDetailScreen from './app/screens/PostDetailScreen';
 import ReplyDetailScreen from './app/screens/ReplyDetailScreen';
 import ProfileScreen from './app/screens/ProfileScreen';
 import UserProfileScreen from './app/screens/UserProfileScreen';
+import OtherUserProfileScreen from './app/screens/OtherUserProfileScreen';
 import FollowListScreen from './app/screens/FollowListScreen';
 import { useAuth } from './AuthContext';
 
@@ -25,6 +26,7 @@ export default function Navigator() {
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="UserProfile" component={UserProfileScreen} />
+          <Stack.Screen name="OtherUserProfile" component={OtherUserProfileScreen} />
           <Stack.Screen name="FollowList" component={FollowListScreen} />
         </>
       ) : (

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -617,12 +617,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
               onProfilePress={() =>
                 isMe
                   ? navigation.navigate('Profile')
-                  : navigation.navigate('UserProfile', {
+                  : navigation.navigate('OtherUserProfile', {
                       userId: item.user_id,
-                      avatarUrl: avatarUri,
-                      bannerUrl: item.profiles?.banner_url,
-                      name: displayName,
-                      username: userName,
                     })
               }
               onDelete={() => confirmDeletePost(item.id)}

--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, Text, StyleSheet, Image, ActivityIndicator, FlatList, Button, TouchableOpacity } from 'react-native';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
+import { supabase } from '../../lib/supabase';
+import { colors } from '../styles/colors';
+import FollowButton from '../components/FollowButton';
+import PostCard from '../components/PostCard';
+import { useAuth } from '../../AuthContext';
+import { useFollowCounts } from '../hooks/useFollowCounts';
+import { usePostStore } from '../contexts/PostStoreContext';
+import { likeEvents } from '../likeEvents';
+import { postEvents } from '../postEvents';
+import { getLikeCounts } from '../../lib/getLikeCounts';
+
+export default function OtherUserProfileScreen() {
+  const route = useRoute();
+  const navigation = useNavigation();
+  const { user } = useAuth()!;
+  const { initialize } = usePostStore();
+  const { userId: routeUserId, username: routeUsername } = route.params || {};
+
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  const idToLoad = profile?.id || routeUserId || null;
+  const { followers, following, refresh } = useFollowCounts(idToLoad);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchProfile = async () => {
+      setLoading(true);
+      setNotFound(false);
+      let query = supabase.from('profiles').select('id, username, name, image_url, banner_url').single();
+      if (routeUserId) query = query.eq('id', routeUserId);
+      else if (routeUsername) query = query.eq('username', routeUsername);
+      const { data, error } = await query;
+      if (isMounted) {
+        if (!error && data) {
+          setProfile({
+            id: data.id,
+            username: data.username,
+            name: data.name,
+            image_url: data.image_url,
+            banner_url: data.banner_url,
+          });
+        } else {
+          setNotFound(true);
+        }
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+    return () => { isMounted = false; };
+  }, [routeUserId, routeUsername]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!idToLoad) return;
+      const loadPosts = async () => {
+        const { data, error } = await supabase
+          .from('posts')
+          .select('id, content, image_url, user_id, created_at, reply_count, like_count, username, profiles(username, name, image_url, banner_url)')
+          .eq('user_id', idToLoad)
+          .order('created_at', { ascending: false });
+        if (!error && data) {
+          const seen = new Set();
+          const unique = data.filter(p => {
+            if (seen.has(p.id)) return false;
+            seen.add(p.id);
+            return true;
+          });
+          setPosts(unique);
+          const counts = await getLikeCounts(unique.map(p => p.id));
+          initialize(unique.map(p => ({ id: p.id, like_count: counts[p.id] })));
+        } else if (error) {
+          console.error('Failed to fetch posts', error);
+        }
+      };
+      loadPosts();
+    }, [idToLoad, initialize])
+  );
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count }) => {
+      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    const onPostDeleted = postId => {
+      setPosts(prev => prev.filter(p => p.id !== postId));
+    };
+    postEvents.on('postDeleted', onPostDeleted);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+      postEvents.off('postDeleted', onPostDeleted);
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <ActivityIndicator color="white" />
+      </View>
+    );
+  }
+
+  if (notFound || !profile) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <Text style={{ color: 'white' }}>Profile not found.</Text>
+        <View style={styles.backButton}>
+          <Button title="Back" onPress={() => navigation.goBack()} />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {profile.banner_url ? (
+        <Image source={{ uri: profile.banner_url }} style={styles.banner} />
+      ) : (
+        <View style={[styles.banner, styles.placeholder]} />
+      )}
+      <View style={styles.backButton}>
+        <Button title="Back" onPress={() => navigation.goBack()} />
+      </View>
+      <View style={styles.profileRow}>
+        {profile.image_url ? (
+          <Image source={{ uri: profile.image_url }} style={styles.avatar} />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        <View style={styles.textContainer}>
+          {profile.name && <Text style={styles.name}>{profile.name}</Text>}
+          <Text style={styles.username}>@{profile.username}</Text>
+        </View>
+        {user && user.id !== profile.id && (
+          <View style={{ marginLeft: 10 }}>
+            <FollowButton targetUserId={profile.id} onToggle={refresh} />
+          </View>
+        )}
+      </View>
+      <View style={styles.statsRow}>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', { userId: profile.id, mode: 'followers' })
+          }
+        >
+          <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', { userId: profile.id, mode: 'following' })
+          }
+        >
+          <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        </TouchableOpacity>
+      </View>
+      <FlatList
+        data={posts}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <PostCard
+            post={item}
+            isOwner={false}
+            avatarUri={profile.image_url || undefined}
+            bannerUrl={item.profiles?.banner_url || undefined}
+            replyCount={item.reply_count ?? 0}
+            onPress={() => navigation.navigate('PostDetail', { post: item })}
+            onProfilePress={() => {}}
+            onDelete={() => {}}
+            onOpenReplies={() => navigation.navigate('PostDetail', { post: item })}
+          />
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: colors.background,
+  },
+  backButton: { alignSelf: 'flex-start', marginBottom: 20 },
+  profileRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
+  banner: { width: '100%', height: 200, marginBottom: 20 },
+  avatar: { width: 80, height: 80, borderRadius: 40 },
+  placeholder: { backgroundColor: '#ffffff20' },
+  textContainer: { marginLeft: 15 },
+  username: { color: 'white', fontSize: 24, fontWeight: 'bold' },
+  name: { color: 'white', fontSize: 20, marginTop: 4 },
+  center: { justifyContent: 'center', alignItems: 'center' },
+  statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
+  statsText: { color: 'white', marginRight: 15 },
+});
+

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -542,12 +542,8 @@ export default function PostDetailScreen() {
             onProfilePress={() =>
               user?.id === post.user_id
                 ? navigation.navigate('Profile')
-                : navigation.navigate('UserProfile', {
+                : navigation.navigate('OtherUserProfile', {
                     userId: post.user_id,
-                    avatarUrl: post.profiles?.image_url,
-                    bannerUrl: post.profiles?.banner_url,
-                    name: displayName,
-                    username: userName,
                   })
             }
             
@@ -581,12 +577,8 @@ export default function PostDetailScreen() {
               onProfilePress={() =>
                 isMe
                   ? navigation.navigate('Profile')
-                  : navigation.navigate('UserProfile', {
+                  : navigation.navigate('OtherUserProfile', {
                       userId: item.user_id,
-                      avatarUrl: avatarUri,
-                      bannerUrl: item.profiles?.banner_url,
-                      name,
-                      username: replyUserName,
                     })
               }
               onDelete={() => confirmDeleteReply(item.id)}

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -583,18 +583,13 @@ export default function ReplyDetailScreen() {
                 )}
                 <View style={styles.row}>
                   <TouchableOpacity
-                    onPress={() =>
-                      user?.id === originalPost.user_id
-                        ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', {
-                            userId: originalPost.user_id,
-                            avatarUrl: originalPost.profiles?.image_url,
-                            bannerUrl: originalPost.profiles?.banner_url,
-
-                            name: originalName,
-                            username: originalUserName,
-                          })
-                    }
+                  onPress={() =>
+                    user?.id === originalPost.user_id
+                      ? navigation.navigate('Profile')
+                      : navigation.navigate('OtherUserProfile', {
+                          userId: originalPost.user_id,
+                        })
+                  }
                   >
                     {user?.id === originalPost.user_id && profileImageUri ? (
                       <Image source={{ uri: profileImageUri }} style={styles.avatar} />
@@ -655,13 +650,8 @@ export default function ReplyDetailScreen() {
                       onPress={() =>
                         isMe
                           ? navigation.navigate('Profile')
-                          : navigation.navigate('UserProfile', {
+                          : navigation.navigate('OtherUserProfile', {
                               userId: a.user_id,
-                              avatarUrl: avatarUri,
-                              bannerUrl: a.profiles?.banner_url,
-
-                              name: ancestorName,
-                              username: ancestorUserName,
                             })
                       }
                     >
@@ -716,13 +706,8 @@ export default function ReplyDetailScreen() {
                   onPress={() =>
                     user?.id === parent.user_id
                       ? navigation.navigate('Profile')
-                      : navigation.navigate('UserProfile', {
+                      : navigation.navigate('OtherUserProfile', {
                           userId: parent.user_id,
-                          avatarUrl: parent.profiles?.image_url,
-                          bannerUrl: parent.profiles?.banner_url,
-
-                          name,
-                          username: parentUserName,
                         })
                   }
                 >
@@ -796,13 +781,8 @@ export default function ReplyDetailScreen() {
                     onPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('UserProfile', {
+                        : navigation.navigate('OtherUserProfile', {
                             userId: item.user_id,
-                            avatarUrl: avatarUri,
-                            bannerUrl: item.profiles?.banner_url,
-
-                            name: childName,
-                            username: childUserName,
                           })
                     }
                   >


### PR DESCRIPTION
## Summary
- navigate to the new `OtherUserProfile` screen when tapping another user's avatar
- keep going to `Profile` when the post or reply belongs to the signed-in user

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9cc03e48322b6ce165b3be85141