### PR TITLE
Add following feed screen

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -6,6 +6,7 @@ import PostDetailScreen from './app/screens/PostDetailScreen';
 import ReplyDetailScreen from './app/screens/ReplyDetailScreen';
 import ProfileScreen from './app/screens/ProfileScreen';
 import UserProfileScreen from './app/screens/UserProfileScreen';
+import OtherUserProfileScreen from './app/screens/OtherUserProfileScreen';
 import FollowListScreen from './app/screens/FollowListScreen';
 import { useAuth } from './AuthContext';
 
@@ -25,6 +26,7 @@ export default function Navigator() {
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="UserProfile" component={UserProfileScreen} />
+          <Stack.Screen name="OtherUserProfile" component={OtherUserProfileScreen} />
           <Stack.Screen name="FollowList" component={FollowListScreen} />
         </>
       ) : (

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -28,19 +28,11 @@ import {
 import { useAuth } from '../AuthContext';
 import { useNavigation } from '@react-navigation/native';
 import HomeScreen, { HomeScreenRef } from './screens/HomeScreen';
+import FollowingFeedScreen from './screens/FollowingFeedScreen';
 import { supabase } from '../lib/supabase';
 import { colors } from './styles/colors';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
-
-
-function FollowingScreen() {
-  return (
-    <View style={{ flex: 1, backgroundColor: '#1d152b', justifyContent: 'center', alignItems: 'center' }}>
-      <Text style={{ color: 'white' }}>Following Content</Text>
-    </View>
-  );
-}
 
 const Tab = createMaterialTopTabNavigator();
 const TAB_BAR_HEIGHT = 48;
@@ -205,7 +197,7 @@ export default function TopTabsNavigator() {
         }}
       >
         <Tab.Screen name="For you" component={ForYouScreen} />
-        <Tab.Screen name="Following" component={FollowingScreen} />
+        <Tab.Screen name="Following" component={FollowingFeedScreen} />
         </Tab.Navigator>
 
         <TouchableOpacity

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
+import { Video } from 'expo-av';
 import useLike from '../hooks/useLike';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../styles/colors';
@@ -8,6 +9,7 @@ export interface Post {
   id: string;
   content: string;
   image_url?: string;
+  video_url?: string;
   user_id: string;
   created_at: string;
   username?: string;
@@ -88,6 +90,15 @@ export default function PostCard({
             {post.image_url && (
               <Image source={{ uri: post.image_url }} style={styles.postImage} />
             )}
+            {!post.image_url && post.video_url && (
+              <Video
+                source={{ uri: post.video_url }}
+                style={styles.postVideo}
+                useNativeControls
+                isMuted
+                resizeMode="contain"
+              />
+            )}
           </View>
         </View>
         <TouchableOpacity style={styles.replyCountContainer} onPress={onOpenReplies}>
@@ -148,6 +159,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   postImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginTop: 8,
+  },
+  postVideo: {
     width: '100%',
     height: 200,
     borderRadius: 6,

--- a/app/screens/FollowingFeedScreen.jsx
+++ b/app/screens/FollowingFeedScreen.jsx
@@ -1,0 +1,138 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import PostCard from '../components/PostCard';
+import { colors } from '../styles/colors';
+import { supabase } from '../../lib/supabase';
+import { useAuth } from '../../AuthContext';
+import { usePostStore } from '../contexts/PostStoreContext';
+import { getLikeCounts } from '../../lib/getLikeCounts';
+import { likeEvents } from '../likeEvents';
+import { postEvents } from '../postEvents';
+
+export default function FollowingFeedScreen() {
+  const { user, profileImageUri } = useAuth()!;
+  const navigation = useNavigation<any>();
+  const { initialize } = usePostStore();
+  const [posts, setPosts] = useState([]);
+  const [replyCounts, setReplyCounts] = useState({});
+  const [loading, setLoading] = useState(true);
+
+  const fetchPosts = async () => {
+    if (!user) return;
+    setLoading(true);
+    const { data: followData, error: followError } = await supabase
+      .from('follows')
+      .select('following_id')
+      .eq('follower_id', user.id);
+
+    if (followError) {
+      console.error('Failed to fetch following list', followError);
+      setPosts([]);
+      setLoading(false);
+      return;
+    }
+
+    const ids = (followData ?? []).map(f => f.following_id);
+    if (ids.length === 0) {
+      setPosts([]);
+      setReplyCounts({});
+      setLoading(false);
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('posts')
+      .select(
+        'id, content, image_url, video_url, user_id, created_at, reply_count, like_count, username, profiles(username, name, image_url, banner_url)'
+      )
+      .in('user_id', ids)
+      .order('created_at', { ascending: false });
+
+    if (!error && data) {
+      const unique = [];
+      const seen = new Set();
+      data.forEach(p => {
+        if (!seen.has(p.id)) {
+          seen.add(p.id);
+          unique.push(p);
+        }
+      });
+      setPosts(unique);
+      const counts = {};
+      unique.forEach(p => {
+        counts[p.id] = p.reply_count ?? 0;
+      });
+      setReplyCounts(counts);
+      const likeCounts = await getLikeCounts(unique.map(p => p.id));
+      initialize(unique.map(p => ({ id: p.id, like_count: likeCounts[p.id] })));
+    } else if (error) {
+      console.error('Failed to fetch posts', error);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count }) => {
+      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
+    };
+    const onPostDeleted = postId => {
+      setPosts(prev => prev.filter(p => p.id !== postId));
+      setReplyCounts(prev => {
+        const { [postId]: _omit, ...rest } = prev;
+        return rest;
+      });
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    postEvents.on('postDeleted', onPostDeleted);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+      postEvents.off('postDeleted', onPostDeleted);
+    };
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchPosts();
+    }, [user?.id])
+  );
+
+  return (
+    <View style={styles.container}>
+      {loading && <ActivityIndicator color="white" style={{ marginTop: 20 }} />}
+      <FlatList
+        data={posts}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => {
+          const isMe = user?.id === item.user_id;
+          const avatarUri = isMe ? profileImageUri : item.profiles?.image_url || undefined;
+          const bannerUrl = isMe ? undefined : item.profiles?.banner_url || undefined;
+          return (
+            <PostCard
+              post={item}
+              isOwner={isMe}
+              avatarUri={avatarUri}
+              bannerUrl={bannerUrl}
+              replyCount={replyCounts[item.id] || 0}
+              onPress={() => navigation.navigate('PostDetail', { post: item })}
+              onProfilePress={() =>
+                isMe
+                  ? navigation.navigate('Profile')
+                  : navigation.navigate('OtherUserProfile', { userId: item.user_id })
+              }
+              onDelete={() => {}}
+              onOpenReplies={() => navigation.navigate('PostDetail', { post: item })}
+            />
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -14,6 +14,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import { Video } from 'expo-av';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -70,6 +71,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
   const [activePostId, setActivePostId] = useState<string | null>(null);
   const [replyText, setReplyText] = useState('');
   const [replyImage, setReplyImage] = useState<string | null>(null);
+  const [replyVideo, setReplyVideo] = useState<string | null>(null);
 
   const confirmDeletePost = (id: string) => {
     Alert.alert("Delete Post", "Are you sure you want to delete this post?", [
@@ -102,6 +104,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     setActivePostId(postId);
     setReplyText('');
     setReplyImage(null);
+    setReplyVideo(null);
     setReplyModalVisible(true);
   };
 
@@ -120,10 +123,25 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     }
   };
 
+  const pickReplyVideo = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.size && info.size > 20 * 1024 * 1024) {
+        Alert.alert('Video too large', 'Please select a video under 20MB.');
+        return;
+      }
+      setReplyVideo(uri);
+    }
+  };
+
   const handleReplySubmit = async () => {
     if (
       !activePostId ||
-      (!replyText.trim() && !replyImage) ||
+      (!replyText.trim() && !replyImage && !replyVideo) ||
       !user
     ) {
 
@@ -140,6 +158,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       user_id: user.id,
       content: replyText,
       image_url: replyImage ?? undefined,
+      video_url: replyVideo ?? undefined,
       created_at: new Date().toISOString(),
       username: profile.name || profile.username,
       reply_count: 0,
@@ -172,6 +191,25 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
 
     setReplyText('');
     setReplyImage(null);
+    setReplyVideo(null);
+
+    let uploadedUrl = null;
+    if (replyVideo) {
+      try {
+        const ext = replyVideo.split('.').pop() || 'mp4';
+        const path = `${user.id}-${Date.now()}.${ext}`;
+        const resp = await fetch(replyVideo);
+        const blob = await resp.blob();
+        const { error: uploadError } = await supabase.storage
+          .from('reply-videos')
+          .upload(path, blob);
+        if (!uploadError) {
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+        }
+      } catch (e) {
+        console.error('Video upload failed', e);
+      }
+    }
 
     let { data, error } = await supabase
       .from('replies')
@@ -181,6 +219,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         user_id: user.id,
         content: replyText,
         image_url: replyImage,
+        video_url: uploadedUrl,
         username: profile.name || profile.username,
       })
       .select()
@@ -225,7 +264,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
     const { data, error } = await supabase
       .from('posts')
       .select(
-        'id, content, image_url, user_id, created_at, reply_count, like_count, profiles(username, name, image_url, banner_url)',
+        'id, content, image_url, video_url, user_id, created_at, reply_count, like_count, profiles(username, name, image_url, banner_url)'
       )
       .order('created_at', { ascending: false })
       .range(0, PAGE_SIZE - 1);
@@ -617,12 +656,8 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
               onProfilePress={() =>
                 isMe
                   ? navigation.navigate('Profile')
-                  : navigation.navigate('UserProfile', {
+                  : navigation.navigate('OtherUserProfile', {
                       userId: item.user_id,
-                      avatarUrl: avatarUri,
-                      bannerUrl: item.profiles?.banner_url,
-                      name: displayName,
-                      username: userName,
                     })
               }
               onDelete={() => confirmDeletePost(item.id)}
@@ -647,8 +682,18 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
             {replyImage && (
               <Image source={{ uri: replyImage }} style={styles.preview} />
             )}
+            {!replyImage && replyVideo && (
+              <Video
+                source={{ uri: replyVideo }}
+                style={styles.preview}
+                useNativeControls
+                isMuted
+                resizeMode="contain"
+              />
+            )}
             <View style={styles.buttonRow}>
               <Button title="Add Image" onPress={pickReplyImage} />
+              <Button title="Add Video" onPress={pickReplyVideo} />
               <Button title="Post" onPress={handleReplySubmit} />
             </View>
           </View>

--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, Text, StyleSheet, Image, ActivityIndicator, FlatList, Button, TouchableOpacity } from 'react-native';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
+import { supabase } from '../../lib/supabase';
+import { colors } from '../styles/colors';
+import FollowButton from '../components/FollowButton';
+import PostCard from '../components/PostCard';
+import { useAuth } from '../../AuthContext';
+import { useFollowCounts } from '../hooks/useFollowCounts';
+import { usePostStore } from '../contexts/PostStoreContext';
+import { likeEvents } from '../likeEvents';
+import { postEvents } from '../postEvents';
+import { getLikeCounts } from '../../lib/getLikeCounts';
+
+export default function OtherUserProfileScreen() {
+  const route = useRoute();
+  const navigation = useNavigation();
+  const { user } = useAuth();
+  const { initialize } = usePostStore();
+  const { userId: routeUserId, username: routeUsername } = route.params || {};
+
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  const idToLoad = profile?.id || routeUserId || null;
+  const { followers, following, refresh } = useFollowCounts(idToLoad);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchProfile = async () => {
+      setLoading(true);
+      setNotFound(false);
+      let query = supabase.from('profiles').select('id, username, name, image_url, banner_url').single();
+      if (routeUserId) query = query.eq('id', routeUserId);
+      else if (routeUsername) query = query.eq('username', routeUsername);
+      const { data, error } = await query;
+      if (isMounted) {
+        if (!error && data) {
+          setProfile({
+            id: data.id,
+            username: data.username,
+            name: data.name,
+            image_url: data.image_url,
+            banner_url: data.banner_url,
+          });
+        } else {
+          setNotFound(true);
+        }
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+    return () => { isMounted = false; };
+  }, [routeUserId, routeUsername]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!idToLoad) return;
+      const loadPosts = async () => {
+        const { data, error } = await supabase
+          .from('posts')
+          .select('id, content, image_url, video_url, user_id, created_at, reply_count, like_count, username, profiles(username, name, image_url, banner_url)')
+          .eq('user_id', idToLoad)
+          .order('created_at', { ascending: false });
+        if (!error && data) {
+          const seen = new Set();
+          const unique = data.filter(p => {
+            if (seen.has(p.id)) return false;
+            seen.add(p.id);
+            return true;
+          });
+          setPosts(unique);
+          const counts = await getLikeCounts(unique.map(p => p.id));
+          initialize(unique.map(p => ({ id: p.id, like_count: counts[p.id] })));
+        } else if (error) {
+          console.error('Failed to fetch posts', error);
+        }
+      };
+      loadPosts();
+    }, [idToLoad, initialize])
+  );
+
+  useEffect(() => {
+    const onLikeChanged = ({ id, count }) => {
+      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
+    };
+    likeEvents.on('likeChanged', onLikeChanged);
+    const onPostDeleted = postId => {
+      setPosts(prev => prev.filter(p => p.id !== postId));
+    };
+    postEvents.on('postDeleted', onPostDeleted);
+    return () => {
+      likeEvents.off('likeChanged', onLikeChanged);
+      postEvents.off('postDeleted', onPostDeleted);
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <ActivityIndicator color="white" />
+      </View>
+    );
+  }
+
+  if (notFound || !profile) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <Text style={{ color: 'white' }}>Profile not found.</Text>
+        <View style={styles.backButton}>
+          <Button title="Back" onPress={() => navigation.goBack()} />
+        </View>
+      </View>
+    );
+  }
+
+  const renderHeader = () => (
+    <View style={styles.headerContainer}>
+      {profile.banner_url ? (
+        <Image source={{ uri: profile.banner_url }} style={styles.banner} />
+      ) : (
+        <View style={[styles.banner, styles.placeholder]} />
+      )}
+      <View style={styles.backButton}>
+        <Button title="Back" onPress={() => navigation.goBack()} />
+      </View>
+      <View style={styles.profileRow}>
+        {profile.image_url ? (
+          <Image source={{ uri: profile.image_url }} style={styles.avatar} />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        <View style={styles.textContainer}>
+          {profile.name && <Text style={styles.name}>{profile.name}</Text>}
+          <Text style={styles.username}>@{profile.username}</Text>
+        </View>
+        {user && user.id !== profile.id && (
+          <View style={{ marginLeft: 10 }}>
+            <FollowButton targetUserId={profile.id} onToggle={refresh} />
+          </View>
+        )}
+      </View>
+      <View style={styles.statsRow}>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', { userId: profile.id, mode: 'followers' })
+          }
+        >
+          <Text style={styles.statsText}>{followers ?? 0} Followers</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('FollowList', { userId: profile.id, mode: 'following' })
+          }
+        >
+          <Text style={styles.statsText}>{following ?? 0} Following</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+
+  return (
+    <FlatList
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      data={posts}
+      ListHeaderComponent={renderHeader}
+      keyExtractor={item => item.id}
+      renderItem={({ item }) => (
+        <PostCard
+          post={item}
+          isOwner={false}
+          avatarUri={profile.image_url || undefined}
+          bannerUrl={item.profiles?.banner_url || undefined}
+          replyCount={item.reply_count ?? 0}
+          onPress={() => navigation.navigate('PostDetail', { post: item })}
+          onProfilePress={() => {}}
+          onDelete={() => {}}
+          onOpenReplies={() => navigation.navigate('PostDetail', { post: item })}
+        />
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  contentContainer: {
+    paddingBottom: 0,
+  },
+  headerContainer: {
+    padding: 20,
+  },
+  backButton: { alignSelf: 'flex-start', marginBottom: 20 },
+  profileRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
+  banner: { width: '100%', height: 200, marginBottom: 20 },
+  avatar: { width: 80, height: 80, borderRadius: 40 },
+  placeholder: { backgroundColor: '#ffffff20' },
+  textContainer: { marginLeft: 15 },
+  username: { color: 'white', fontSize: 24, fontWeight: 'bold' },
+  name: { color: 'white', fontSize: 20, marginTop: 4 },
+  center: { justifyContent: 'center', alignItems: 'center' },
+  statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
+  statsText: { color: 'white', marginRight: 15 },
+});
+

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -13,6 +13,7 @@ import {
   Alert,
   Image,
 } from 'react-native';
+import { Video } from 'expo-av';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -74,6 +75,7 @@ export default function PostDetailScreen() {
 
   const [replyText, setReplyText] = useState('');
   const [replyImage, setReplyImage] = useState<string | null>(null);
+  const [replyVideo, setReplyVideo] = useState<string | null>(null);
   const [replies, setReplies] = useState<Reply[]>([]);
   const [allReplies, setAllReplies] = useState<Reply[]>([]);
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
@@ -101,6 +103,21 @@ export default function PostDetailScreen() {
       const uri = result.assets[0].uri;
       const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
       setReplyImage(`data:image/jpeg;base64,${base64}`);
+    }
+  };
+
+  const pickVideo = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.size && info.size > 20 * 1024 * 1024) {
+        Alert.alert('Video too large', 'Please select a video under 20MB.');
+        return;
+      }
+      setReplyVideo(uri);
     }
   };
 
@@ -230,7 +247,7 @@ export default function PostDetailScreen() {
     const { data, error } = await supabase
       .from('replies')
       .select(
-        'id, post_id, parent_id, user_id, content, image_url, created_at, reply_count, like_count, username, profiles(username, name, image_url, banner_url)'
+        'id, post_id, parent_id, user_id, content, image_url, video_url, created_at, reply_count, like_count, username, profiles(username, name, image_url, banner_url)'
       )
 
 
@@ -413,7 +430,7 @@ export default function PostDetailScreen() {
 
 
   const handleReply = async () => {
-    if ((!replyText.trim() && !replyImage) || !user) return;
+    if ((!replyText.trim() && !replyImage && !replyVideo) || !user) return;
 
     const newReply: Reply = {
       id: `temp-${Date.now()}`,
@@ -422,6 +439,7 @@ export default function PostDetailScreen() {
       user_id: user.id,
       content: replyText,
       image_url: replyImage ?? undefined,
+      video_url: replyVideo ?? undefined,
       created_at: new Date().toISOString(),
       username: profile.name || profile.username,
       reply_count: 0,
@@ -454,6 +472,25 @@ export default function PostDetailScreen() {
     replyEvents.emit('replyAdded', post.id);
     setReplyText('');
     setReplyImage(null);
+    setReplyVideo(null);
+
+    let uploadedUrl = null;
+    if (replyVideo) {
+      try {
+        const ext = replyVideo.split('.').pop() || 'mp4';
+        const path = `${user.id}-${Date.now()}.${ext}`;
+        const resp = await fetch(replyVideo);
+        const blob = await resp.blob();
+        const { error: uploadError } = await supabase.storage
+          .from('reply-videos')
+          .upload(path, blob);
+        if (!uploadError) {
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+        }
+      } catch (e) {
+        console.error('Video upload failed', e);
+      }
+    }
 
     let { data, error } = await supabase
 
@@ -465,6 +502,7 @@ export default function PostDetailScreen() {
             user_id: user.id,
             content: replyText,
             image_url: replyImage,
+            video_url: uploadedUrl,
             username: profile.name || profile.username,
           },
         ])
@@ -542,12 +580,8 @@ export default function PostDetailScreen() {
             onProfilePress={() =>
               user?.id === post.user_id
                 ? navigation.navigate('Profile')
-                : navigation.navigate('UserProfile', {
+                : navigation.navigate('OtherUserProfile', {
                     userId: post.user_id,
-                    avatarUrl: post.profiles?.image_url,
-                    bannerUrl: post.profiles?.banner_url,
-                    name: displayName,
-                    username: userName,
                   })
             }
             
@@ -581,12 +615,8 @@ export default function PostDetailScreen() {
               onProfilePress={() =>
                 isMe
                   ? navigation.navigate('Profile')
-                  : navigation.navigate('UserProfile', {
+                  : navigation.navigate('OtherUserProfile', {
                       userId: item.user_id,
-                      avatarUrl: avatarUri,
-                      bannerUrl: item.profiles?.banner_url,
-                      name,
-                      username: replyUserName,
                     })
               }
               onDelete={() => confirmDeleteReply(item.id)}
@@ -607,8 +637,18 @@ export default function PostDetailScreen() {
         {replyImage && (
           <Image source={{ uri: replyImage }} style={styles.preview} />
         )}
+        {!replyImage && replyVideo && (
+          <Video
+            source={{ uri: replyVideo }}
+            style={styles.preview}
+            useNativeControls
+            isMuted
+            resizeMode="contain"
+          />
+        )}
         <View style={styles.buttonRow}>
           <Button title="Add Image" onPress={pickImage} />
+          <Button title="Add Video" onPress={pickVideo} />
           <Button title="Post" onPress={handleReply} />
         </View>
       </View>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-router": "^5.0.6",
     "expo-status-bar": "~2.2.3",
     "expo-image-picker": "~16.1.4",
+    "expo-av": "~13.2.1",
     "expo-blur": "~12.4.0",
     "process": "^0.11.10",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- display posts from followed users using `FollowingFeedScreen`
- register the screen in `TopTabsNavigator`
- add expo-av and display video previews
- support uploading short videos in reply modals and detail screens

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9cc03e48322b6ce165b3be85141