### PR TITLE
Fix video touch handling in PostCard

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, Image, StyleSheet, TouchableWithoutFeedback } from 'react-native';
 import { Video } from 'expo-av';
 import useLike from '../hooks/useLike';
 import { Ionicons } from '@expo/vector-icons';
@@ -91,13 +91,18 @@ export default function PostCard({
               <Image source={{ uri: post.image_url }} style={styles.postImage} />
             )}
             {!post.image_url && post.video_url && (
-              <Video
-                source={{ uri: post.video_url }}
-                style={styles.postVideo}
-                useNativeControls
-                isMuted
-                resizeMode="contain"
-              />
+              <TouchableWithoutFeedback onPressIn={e => e.stopPropagation()}>
+                <View>
+                  <Video
+                    source={{ uri: post.video_url }}
+                    style={styles.postVideo}
+                    useNativeControls
+                    isMuted
+                    resizeMode="contain"
+                    onTouchStart={e => e.stopPropagation()}
+                  />
+                </View>
+              </TouchableWithoutFeedback>
             )}
           </View>
         </View>


### PR DESCRIPTION
## Summary
- ensure the PostCard video doesn't trigger navigation

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find expo tsconfig and other dependencies)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_684702eccdc08322bc8c6d48f39320c9