### PR TITLE
Add replies tab on profile screen

### DIFF
--- a/app/components/ReplyCard.tsx
+++ b/app/components/ReplyCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PostCard, { PostCardProps, Post } from './PostCard';
+
+export interface Reply extends Post {
+  post_id: string;
+  parent_id: string | null;
+}
+
+export interface ReplyCardProps extends Omit<PostCardProps, 'post'> {
+  reply: Reply;
+}
+
+export default function ReplyCard({ reply, ...props }: ReplyCardProps) {
+  return <PostCard post={reply} {...props} />;
+}


### PR DESCRIPTION
## Summary
- add a simple `ReplyCard` component
- fetch and show user replies in a new tab
- display posts and replies via a top tab navigator

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6847d11c59e08322a23157c15b510ec9