### PR TITLE
Add basic bottom tab navigation

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import AuthPage from './AuthPage';
 import TopTabsNavigator from './app/TopTabsNavigator';
+import BottomTabsNavigator from './bottomtabs/BottomTabsNavigator';
 import LoadingScreen from './app/components/LoadingScreen';
 
 const PostDetailScreen = React.lazy(() => import('./app/screens/PostDetailScreen'));
@@ -25,6 +26,7 @@ export default function Navigator() {
       {user ? (
         <>
           <Stack.Screen name="Tabs" component={TopTabsNavigator} />
+          <Stack.Screen name="BottomTabs" component={BottomTabsNavigator} />
           <Stack.Screen name="PostDetail" component={PostDetailScreen} />
           <Stack.Screen name="ReplyDetail" component={ReplyDetailScreen} />
           <Stack.Screen name="Profile" component={ProfileScreen} />

--- a/bottomtabs/BottomTabsNavigator.js
+++ b/bottomtabs/BottomTabsNavigator.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
+import { Dimensions } from 'react-native';
+
+import HomeScreen from './HomeScreen';
+import SearchScreen from './SearchScreen';
+import MarketScreen from './MarketScreen';
+import VideoScreen from './VideoScreen';
+import NotificationsScreen from './NotificationsScreen';
+
+const Tab = createBottomTabNavigator();
+const { height } = Dimensions.get('window');
+
+export default function BottomTabsNavigator() {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarShowLabel: true,
+        tabBarLabelStyle: { fontSize: 12, marginBottom: 4 },
+        tabBarStyle: {
+          position: 'absolute',
+          bottom: 0,
+          height: height * 0.1,
+          width: '100%',
+          backgroundColor: 'rgba(255,255,255,0.9)',
+          borderTopWidth: 0,
+          elevation: 5,
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.2,
+          shadowRadius: 4,
+        },
+        tabBarIcon: ({ focused, color, size }) => {
+          let iconName = 'home-outline';
+          if (route.name === 'Home') iconName = 'home-outline';
+          else if (route.name === 'Search') iconName = 'search-outline';
+          else if (route.name === 'Market') iconName = 'car-outline';
+          else if (route.name === 'Video') iconName = 'play-circle-outline';
+          else if (route.name === 'Notifications') iconName = 'notifications-outline';
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+      })}
+    >
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Search" component={SearchScreen} />
+      <Tab.Screen name="Market" component={MarketScreen} />
+      <Tab.Screen name="Video" component={VideoScreen} />
+      <Tab.Screen name="Notifications" component={NotificationsScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/bottomtabs/HomeScreen.js
+++ b/bottomtabs/HomeScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Home Page</Text>
+    </View>
+  );
+}

--- a/bottomtabs/MarketScreen.js
+++ b/bottomtabs/MarketScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function MarketScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Market Page</Text>
+    </View>
+  );
+}

--- a/bottomtabs/NotificationsScreen.js
+++ b/bottomtabs/NotificationsScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function NotificationsScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Notifications Page</Text>
+    </View>
+  );
+}

--- a/bottomtabs/SearchScreen.js
+++ b/bottomtabs/SearchScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function SearchScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Search Page</Text>
+    </View>
+  );
+}

--- a/bottomtabs/VideoScreen.js
+++ b/bottomtabs/VideoScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function VideoScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Video Page</Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a sample bottom tab navigator using React Navigation
- add five placeholder screens for bottom tabs
- expose the bottom tab navigator through the existing navigator

## Testing
- `npm start -- --help` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a964ebd908322957016c25798ac56