### PR TITLE
Apply dark theme colors

### DIFF
--- a/AuthPage.js
+++ b/AuthPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, TouchableOpacity, StyleSheet, Alert } from 'react-native';
+import { colors } from './app/styles/colors';
 
 import { useAuth } from './AuthContext';
 import { useNavigation } from '@react-navigation/native';
@@ -125,11 +126,13 @@ const styles = StyleSheet.create({
   container: {
     padding: 20,
     marginTop: 80,
+    backgroundColor: colors.background,
   },
   title: {
     fontSize: 28,
     marginBottom: 20,
     textAlign: 'center',
+    color: colors.text,
   },
   input: {
     width: '100%',
@@ -138,6 +141,8 @@ const styles = StyleSheet.create({
     borderColor: '#aaa',
     marginBottom: 12,
     borderRadius: 5,
+    color: colors.text,
+    backgroundColor: colors.background,
   },
   error: {
     color: 'red',
@@ -147,6 +152,6 @@ const styles = StyleSheet.create({
   toggle: {
     marginTop: 20,
     textAlign: 'center',
-    color: 'blue',
+    color: colors.accent,
   },
 });

--- a/HomePage.js
+++ b/HomePage.js
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from './AuthContext';
+import { colors } from './app/styles/colors';
 
 export default function HomePage() {
   const navigation = useNavigation();
@@ -43,13 +44,13 @@ export default function HomePage() {
 const styles = StyleSheet.create({
   container: {
     padding: 20,
-    backgroundColor: '#061e45',
+    backgroundColor: colors.background,
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
   text: {
-    color: 'white',
+    color: colors.text,
     marginBottom: 20,
     fontSize: 16,
   },

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -63,7 +63,7 @@ function HeaderTabBar(
       style={[styles.headerBlur, { paddingTop: insetsTop + 10 }]}
     >
       <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
-      <Text style={{ color: 'white', textAlign: 'center' }}>{welcomeText}</Text>
+      <Text style={{ color: colors.text, textAlign: 'center' }}>{welcomeText}</Text>
       <View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 10 }}>
         <Button title="Profile" onPress={onProfile} />
         <Button title="Logout" onPress={signOut} />
@@ -216,12 +216,13 @@ export default function TopTabsNavigator() {
             marginTop: 0,
           },
           tabBarLabelStyle: {
-            color: 'white',
+            color: colors.text,
             fontWeight: 'bold',
           },
           tabBarIndicatorStyle: {
-            backgroundColor: '#7814db',
+            backgroundColor: colors.accent,
           },
+          tabBarActiveTintColor: colors.accent,
         }}
       >
         <Tab.Screen name="For you" component={ForYouScreen} />
@@ -238,7 +239,7 @@ export default function TopTabsNavigator() {
           onPress={() => setModalVisible(true)}
           style={styles.fab}
         >
-          <Text style={{ color: 'white', fontSize: 24 }}>+</Text>
+          <Text style={{ color: colors.text, fontSize: 24 }}>+</Text>
         </TouchableOpacity>
 
         <Modal visible={modalVisible} animationType="slide" transparent>
@@ -302,16 +303,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   modalContent: {
-    backgroundColor: '#1d152b',
+    backgroundColor: colors.background,
     padding: 20,
     borderRadius: 8,
     width: '80%',
   },
   input: {
-    backgroundColor: 'white',
+    backgroundColor: colors.background,
     padding: 10,
     borderRadius: 6,
     marginBottom: 10,
+    color: colors.text,
   },
   preview: {
     width: '100%',
@@ -328,7 +330,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 20,
     right: 20,
-    backgroundColor: '#7814db',
+    backgroundColor: colors.accent,
     width: 56,
     height: 56,
     borderRadius: 28,
@@ -355,13 +357,13 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     width: DRAWER_WIDTH,
-    backgroundColor: '#1d152b',
+    backgroundColor: colors.background,
     paddingTop: 100,
     paddingHorizontal: 20,
     zIndex: 30,
   },
   menuItem: {
-    color: 'white',
+    color: colors.text,
     paddingVertical: 10,
     fontSize: 16,
   },

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -110,7 +110,7 @@ function PostCard({
           </View>
         </View>
         <TouchableOpacity style={styles.replyCountContainer} onPress={onOpenReplies}>
-          <Ionicons name="chatbubble-outline" size={18} color="#66538f" style={{ marginRight: 2 }} />
+          <Ionicons name="chatbubble-outline" size={18} color={colors.accent} style={{ marginRight: 2 }} />
           <Text style={styles.replyCountLarge}>{replyCount}</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.likeContainer} onPress={toggleLike}>
@@ -126,12 +126,12 @@ export default React.memo(PostCard);
 
 const styles = StyleSheet.create({
   post: {
-    backgroundColor: '#ffffff10',
+    backgroundColor: colors.background,
     borderRadius: 0,
     padding: 10,
     paddingBottom: 30,
     marginBottom: 0,
-    borderBottomColor: 'gray',
+    borderBottomColor: '#444',
     borderBottomWidth: StyleSheet.hairlineWidth,
     position: 'relative',
   },
@@ -144,10 +144,10 @@ const styles = StyleSheet.create({
     top: 6,
     padding: 5,
   },
-  deleteText: { color: 'white', fontSize: 18 },
-  postContent: { color: 'white' },
-  username: { fontWeight: 'bold', color: 'white' },
-  timestamp: { fontSize: 10, color: 'gray' },
+  deleteText: { color: colors.text, fontSize: 18 },
+  postContent: { color: colors.text },
+  username: { fontWeight: 'bold', color: colors.text },
+  timestamp: { fontSize: 10, color: colors.muted },
   headerRow: { flexDirection: 'row', alignItems: 'center' },
   timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
@@ -157,8 +157,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  replyCountLarge: { fontSize: 15, color: 'gray' },
-  likeCountLarge: { fontSize: 15, color: 'gray' },
+  replyCountLarge: { fontSize: 15, color: colors.muted },
+  likeCountLarge: { fontSize: 15, color: colors.muted },
   likedLikeCount: { color: 'red' },
   likeContainer: {
     position: 'absolute',
@@ -186,7 +186,7 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: -10,
     width: 2,
-    backgroundColor: '#66538f',
+    backgroundColor: colors.accent,
     zIndex: -1,
   },
 });

--- a/app/screens/FollowingFeedScreen.jsx
+++ b/app/screens/FollowingFeedScreen.jsx
@@ -129,7 +129,7 @@ export default function FollowingFeedScreen() {
 
   return (
     <View style={styles.container}>
-      {loading && <ActivityIndicator color="white" style={{ marginTop: 20 }} />}
+      {loading && <ActivityIndicator color={colors.accent} style={{ marginTop: 20 }} />}
       <FlatList
         data={posts}
         keyExtractor={item => item.id}
@@ -144,7 +144,7 @@ export default function FollowingFeedScreen() {
         }}
         onEndReachedThreshold={0.5}
         ListFooterComponent={loadingMore ? (
-          <ActivityIndicator color="white" style={{ marginVertical: 10 }} />
+          <ActivityIndicator color={colors.accent} style={{ marginVertical: 10 }} />
         ) : null}
         renderItem={({ item }) => {
           const isMe = user?.id === item.user_id;

--- a/app/screens/FollowingListScreen.tsx
+++ b/app/screens/FollowingListScreen.tsx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#555',
   },
   username: {
-    color: 'white',
+    color: colors.text,
     fontSize: 16,
   },
 });

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -818,10 +818,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   input: {
-    backgroundColor: 'white',
+    backgroundColor: colors.background,
     padding: 10,
     borderRadius: 6,
     marginBottom: 10,
+    color: colors.text,
   },
   modalOverlay: {
     flex: 1,
@@ -844,7 +845,7 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   errorText: {
-    color: 'white',
+    color: colors.text,
     textAlign: 'center',
     marginTop: 20,
   },

--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -110,7 +110,7 @@ export default function OtherUserProfileScreen() {
   if (notFound || !profile) {
     return (
       <View style={[styles.container, styles.center]}>
-        <Text style={{ color: 'white' }}>Profile not found.</Text>
+        <Text style={{ color: colors.text }}>Profile not found.</Text>
         <View style={styles.backButton}>
           <Button title="Back" onPress={() => navigation.goBack()} />
         </View>
@@ -205,12 +205,12 @@ const styles = StyleSheet.create({
   profileRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
   banner: { width: '100%', height: 200, marginBottom: 20 },
   avatar: { width: 80, height: 80, borderRadius: 40 },
-  placeholder: { backgroundColor: '#ffffff20' },
+  placeholder: { backgroundColor: '#555' },
   textContainer: { marginLeft: 15 },
-  username: { color: 'white', fontSize: 24, fontWeight: 'bold' },
-  name: { color: 'white', fontSize: 20, marginTop: 4 },
+  username: { color: colors.text, fontSize: 24, fontWeight: 'bold' },
+  name: { color: colors.text, fontSize: 20, marginTop: 4 },
   center: { justifyContent: 'center', alignItems: 'center' },
   statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
-  statsText: { color: 'white', marginRight: 15 },
+  statsText: { color: colors.text, marginRight: 15 },
 });
 

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -664,10 +664,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   input: {
-    backgroundColor: 'white',
+    backgroundColor: colors.background,
     padding: 10,
     borderRadius: 6,
     marginBottom: 10,
+    color: colors.text,
   },
   backButton: {
     alignSelf: 'flex-start',

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -658,39 +658,40 @@ const styles = StyleSheet.create({
     borderRadius: 40,
   },
   placeholder: {
-    backgroundColor: '#ffffff20',
+    backgroundColor: '#555',
   },
   textContainer: {
     marginLeft: 15,
   },
   username: {
-    color: 'white',
+    color: colors.text,
     fontSize: 24,
     fontWeight: 'bold',
   },
   name: {
-    color: 'white',
+    color: colors.text,
     fontSize: 20,
     marginTop: 4,
   },
   uploadLink: {
     marginTop: 20,
     padding: 10,
-    backgroundColor: '#ffffff10',
+    backgroundColor: colors.background,
     borderRadius: 6,
     alignSelf: 'flex-start',
   },
-  uploadText: { color: 'white' },
+  uploadText: { color: colors.text },
   statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
-  statsText: { color: 'white', marginRight: 15 },
+  statsText: { color: colors.text, marginRight: 15 },
   headerContainer: {
     padding: 20,
   },
   input: {
-    backgroundColor: 'white',
+    backgroundColor: colors.background,
     padding: 10,
     borderRadius: 6,
     marginBottom: 10,
+    color: colors.text,
   },
   modalOverlay: {
     flex: 1,
@@ -714,7 +715,7 @@ const styles = StyleSheet.create({
   },
   tabBar: {
     flexDirection: 'row',
-    borderBottomColor: '#ffffff30',
+    borderBottomColor: '#444',
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   tabItem: {
@@ -723,15 +724,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   tabLabel: {
-    color: 'white',
+    color: colors.text,
     fontWeight: 'bold',
   },
   activeTab: {
-    borderBottomColor: '#7814db',
+    borderBottomColor: colors.accent,
     borderBottomWidth: 2,
   },
   emptyText: {
-    color: 'white',
+    color: colors.text,
     textAlign: 'center',
     padding: 20,
   },

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -618,7 +618,7 @@ export default function ReplyDetailScreen() {
                       style={styles.deleteButton}
                     >
 
-                    <Text style={{ color: 'white' }}>X</Text>
+                    <Text style={{ color: colors.text }}>X</Text>
                   </TouchableOpacity>
                 )}
                 <View style={styles.row}>
@@ -666,7 +666,7 @@ export default function ReplyDetailScreen() {
                   <Ionicons
                     name="chatbubble-outline"
                     size={18}
-                    color="#66538f"
+                    color={colors.accent}
                     style={{ marginRight: 2 }}
                   />
                   <Text style={styles.replyCountLarge}>{replyCounts[originalPost.id] || 0}</Text>
@@ -691,7 +691,7 @@ export default function ReplyDetailScreen() {
                       onPress={() => confirmDeleteReply(a.id)}
                       style={styles.deleteButton}
                     >
-                      <Text style={{ color: 'white' }}>X</Text>
+                      <Text style={{ color: colors.text }}>X</Text>
                     </TouchableOpacity>
                   )}
                   <View style={styles.row}>
@@ -739,7 +739,7 @@ export default function ReplyDetailScreen() {
                   <Ionicons
                     name="chatbubble-outline"
                     size={18}
-                    color="#66538f"
+                    color={colors.accent}
                     style={{ marginRight: 2 }}
                   />
                   <Text style={styles.replyCountLarge}>{replyCounts[a.id] || 0}</Text>
@@ -756,7 +756,7 @@ export default function ReplyDetailScreen() {
                   onPress={() => confirmDeleteReply(parent.id)}
                   style={styles.deleteButton}
                 >
-                  <Text style={{ color: 'white' }}>X</Text>
+                  <Text style={{ color: colors.text }}>X</Text>
                 </TouchableOpacity>
               )}
               <View style={styles.row}>
@@ -804,7 +804,7 @@ export default function ReplyDetailScreen() {
             <Ionicons
               name="chatbubble-outline"
               size={18}
-              color="#66538f"
+              color={colors.accent}
               style={{ marginRight: 2 }}
             />
             <Text style={styles.replyCountLarge}>{replyCounts[parent.id] || 0}</Text>
@@ -840,7 +840,7 @@ export default function ReplyDetailScreen() {
                     onPress={() => confirmDeleteReply(item.id)}
                     style={styles.deleteButton}
                   >
-                    <Text style={{ color: 'white' }}>X</Text>
+                    <Text style={{ color: colors.text }}>X</Text>
                   </TouchableOpacity>
                 )}
                 <View style={styles.row}>
@@ -888,7 +888,7 @@ export default function ReplyDetailScreen() {
                   <Ionicons
                     name="chatbubble-outline"
                     size={18}
-                    color="#66538f"
+                    color={colors.accent}
                     style={{ marginRight: 2 }}
                   />
                   <Text style={styles.replyCountLarge}>{replyCounts[item.id] || 0}</Text>
@@ -940,11 +940,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   post: {
-    backgroundColor: '#ffffff10',
+    backgroundColor: colors.background,
     borderRadius: 0,
     padding: 10,
     marginBottom: 0,
-    borderBottomColor: 'gray',
+    borderBottomColor: '#444',
     borderBottomWidth: StyleSheet.hairlineWidth,
 
     position: 'relative',
@@ -953,11 +953,11 @@ const styles = StyleSheet.create({
   avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 8 },
   placeholder: { backgroundColor: '#555' },
   reply: {
-    backgroundColor: '#ffffff10',
+    backgroundColor: colors.background,
     borderRadius: 0,
     padding: 10,
     marginTop: 0,
-    borderBottomColor: 'gray',
+    borderBottomColor: '#444',
     borderBottomWidth: StyleSheet.hairlineWidth,
 
     position: 'relative',
@@ -972,17 +972,17 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: -10,
     width: 2,
-    backgroundColor: '#66538f',
+    backgroundColor: colors.accent,
     zIndex: -1,
   },
   highlightPost: {
-    borderColor: '#4f1fde',
+    borderColor: colors.accent,
     borderWidth: 2,
 
   },
-  postContent: { color: 'white' },
-  username: { fontWeight: 'bold', color: 'white' },
-  timestamp: { fontSize: 10, color: 'gray' },
+  postContent: { color: colors.text },
+  username: { fontWeight: 'bold', color: colors.text },
+  timestamp: { fontSize: 10, color: colors.muted },
   headerRow: { flexDirection: 'row', alignItems: 'center' },
   timestampMargin: { marginLeft: 6 },
   replyCountContainer: {
@@ -994,9 +994,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  replyCount: { fontSize: 10, color: 'gray' },
-  replyCountLarge: { fontSize: 15, color: 'gray' },
-  likeCountLarge: { fontSize: 15, color: 'gray' },
+  replyCount: { fontSize: 10, color: colors.muted },
+  replyCountLarge: { fontSize: 15, color: colors.muted },
+  likeCountLarge: { fontSize: 15, color: colors.muted },
   likedLikeCount: { color: 'red' },
   likeContainer: {
     position: 'absolute',
@@ -1021,10 +1021,11 @@ const styles = StyleSheet.create({
   },
 
   input: {
-    backgroundColor: 'white',
+    backgroundColor: colors.background,
     padding: 10,
     borderRadius: 6,
     marginBottom: 10,
+    color: colors.text,
   },
   backButton: {
     alignSelf: 'flex-start',

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -334,7 +334,7 @@ export default function UserProfileScreen() {
           </TouchableOpacity>
 
         </View>
-        <Text style={{ color: 'white', marginTop: 10 }}>Profile not found.</Text>
+        <Text style={{ color: colors.text, marginTop: 10 }}>Profile not found.</Text>
         <View style={styles.backButton}>
           <Button title="Back" onPress={() => navigation.goBack()} />
         </View>
@@ -466,17 +466,17 @@ const styles = StyleSheet.create({
     height: 80,
     borderRadius: 40,
   },
-  placeholder: { backgroundColor: '#ffffff20' },
+  placeholder: { backgroundColor: '#555' },
   textContainer: { marginLeft: 15 },
-  username: { color: 'white', fontSize: 24, fontWeight: 'bold' },
-  name: { color: 'white', fontSize: 20, marginTop: 4 },
+  username: { color: colors.text, fontSize: 24, fontWeight: 'bold' },
+  name: { color: colors.text, fontSize: 20, marginTop: 4 },
   center: { justifyContent: 'center', alignItems: 'center' },
   statsRow: { flexDirection: 'row', marginLeft: 15, marginBottom: 20 },
-  statsText: { color: 'white', marginRight: 15 },
-  sectionTitle: { color: 'white', fontSize: 18, marginBottom: 10 },
+  statsText: { color: colors.text, marginRight: 15 },
+  sectionTitle: { color: colors.text, fontSize: 18, marginBottom: 10 },
   followingRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 12 },
   followingAvatar: { width: 40, height: 40, borderRadius: 20, marginRight: 12 },
-  followingName: { color: 'white', fontSize: 16, fontWeight: 'bold' },
-  followingUsername: { color: 'white', fontSize: 16 },
+  followingName: { color: colors.text, fontSize: 16, fontWeight: 'bold' },
+  followingUsername: { color: colors.text, fontSize: 16 },
 
 });

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -1,5 +1,7 @@
 export const colors = {
-    background: '#1d152b',
-    text: '#FFFFFF',
-  };
+  background: '#2c2c54',
+  text: '#f0f0f0',
+  accent: '#0070f3',
+  muted: '#cccccc',
+};
   

--- a/bottomtabs/BottomTabsNavigator.js
+++ b/bottomtabs/BottomTabsNavigator.js
@@ -3,6 +3,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { Dimensions } from 'react-native';
+import { colors } from '../app/styles/colors';
 
 import TopTabsNavigator from '../app/TopTabsNavigator';
 
@@ -55,13 +56,13 @@ export default function BottomTabsNavigator() {
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarShowLabel: true,
-        tabBarLabelStyle: { fontSize: 12, marginBottom: 4 },
+        tabBarLabelStyle: { fontSize: 12, marginBottom: 4, color: colors.text },
         tabBarStyle: {
           position: 'absolute',
           bottom: 0,
           height: height * 0.1,
           width: '100%',
-          backgroundColor: 'rgba(255,255,255,0.9)',
+          backgroundColor: 'rgba(44,44,84,0.9)',
           borderTopWidth: 0,
           elevation: 5,
           shadowColor: '#000',
@@ -69,6 +70,7 @@ export default function BottomTabsNavigator() {
           shadowOpacity: 0.2,
           shadowRadius: 4,
         },
+        tabBarActiveTintColor: colors.accent,
         tabBarIcon: ({ focused, color, size }) => {
           let iconName = 'home-outline';
           if (route.name === 'Home') iconName = 'home-outline';

--- a/screens/SignUpScreen.jsx
+++ b/screens/SignUpScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, Text, StyleSheet, Alert } from 'react-native';
+import { colors } from '../app/styles/colors';
 import { supabase } from '../lib/supabase';
 
 export default function SignInScreen({ navigation }) {
@@ -47,7 +48,25 @@ export default function SignInScreen({ navigation }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 24 },
-  title: { fontSize: 24, textAlign: 'center', marginBottom: 16 },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 10, marginBottom: 12, borderRadius: 6 },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: colors.background,
+  },
+  title: {
+    fontSize: 24,
+    textAlign: 'center',
+    marginBottom: 16,
+    color: colors.text,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 12,
+    borderRadius: 6,
+    color: colors.text,
+    backgroundColor: colors.background,
+  },
 });


### PR DESCRIPTION
## Summary
- set global dark theme colors
- use dark background & accent blue across screens
- update post and reply cards for consistent text colors
- style bottom and top tab navigators with new accent

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa187d82883228c1428c4a4064334