### PR TITLE
Add header logo

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -65,6 +65,13 @@ function HeaderTabBar(
       style={[styles.headerBlur, { paddingTop: insetsTop + 10 }]}
     >
       <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
+      <View style={{ alignItems: 'center', marginBottom: 10 }}>
+        <Image
+          source={require('../assets/logo.png')}
+          style={styles.logo}
+          resizeMode="contain"
+        />
+      </View>
       <Text style={{ color: colors.text, textAlign: 'center' }}>{welcomeText}</Text>
       <View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 10 }}>
         <Button title="Profile" onPress={onProfile} />
@@ -378,5 +385,9 @@ const styles = StyleSheet.create({
     bottom: 0,
     backgroundColor: 'black',
     zIndex: 25,
+  },
+  logo: {
+    width: 120,
+    height: 40,
   },
 });


### PR DESCRIPTION
## Summary
- add a new logo image above the Profile and Logout buttons

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ab29245d48322944ccff5bce2e2d2