### PR TITLE
Implement video upload tracking for feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql` **and** `sql/follows.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql` **and** `sql/videos.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed.
 
 
 3. Copy your project's URL and `anon` key into `lib/supabase.js`.
-4. Install dependencies with `npm install`.
+4. Install dependencies with `npm install`. The app now depends on `react-native-video` for the video feed.
 
 With the database configured you can run `npm start` to launch the Expo app.

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -511,6 +511,13 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
       error = null;
     }
 
+    if (!error && uploadedVideoUrl) {
+      await supabase.from('videos').insert({
+        user_id: user.id,
+        video_url: uploadedVideoUrl,
+      });
+    }
+
     if (!error) {
       if (data) {
         // Update the optimistic post with the real data from Supabase

--- a/bottomtabs/VideoScreen.js
+++ b/bottomtabs/VideoScreen.js
@@ -1,10 +1,76 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { View, StyleSheet, Dimensions, FlatList } from 'react-native';
+import Video from 'react-native-video';
+import { supabase } from '../lib/supabase';
+import { colors } from '../app/styles/colors';
 
 export default function VideoScreen() {
+  const [videos, setVideos] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const viewabilityConfig = { viewAreaCoveragePercentThreshold: 80 };
+  const onViewableItemsChanged = useRef(({ viewableItems }) => {
+    if (viewableItems.length > 0) {
+      setCurrentIndex(viewableItems[0].index);
+    }
+  });
+
+  useEffect(() => {
+    const fetchVideos = async () => {
+      const { data, error } = await supabase
+        .from('videos')
+        .select('id, user_id, video_url, created_at')
+        .order('created_at', { ascending: false });
+      if (!error && data) {
+        setVideos(data);
+      } else {
+        console.error('Failed to fetch videos', error);
+      }
+    };
+    fetchVideos();
+  }, []);
+
+  const renderItem = ({ item, index }) => (
+    <View style={styles.videoContainer}>
+      <Video
+        source={{ uri: item.video_url }}
+        style={styles.video}
+        resizeMode="contain"
+        paused={currentIndex !== index}
+        repeat
+        muted={false}
+      />
+    </View>
+  );
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Video Page</Text>
+    <View style={styles.container}>
+      <FlatList
+        data={videos}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        pagingEnabled
+        showsVerticalScrollIndicator={false}
+        onViewableItemsChanged={onViewableItemsChanged.current}
+        viewabilityConfig={viewabilityConfig}
+      />
     </View>
   );
 }
+
+const { height } = Dimensions.get('window');
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  videoContainer: {
+    height,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  video: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-image-picker": "~16.1.4",
     "expo-av": "~13.2.1",
+    "react-native-video": "^6.1.0",
     "expo-blur": "~12.4.0",
     "process": "^0.11.10",
     "react": "19.0.0",

--- a/sql/videos.sql
+++ b/sql/videos.sql
@@ -1,0 +1,20 @@
+-- Table for storing video posts
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.videos (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  video_url text not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.videos enable row level security;
+
+create policy "Users can insert videos" on public.videos
+  for insert with check (auth.uid() = user_id);
+
+create policy "Anyone can read videos" on public.videos
+  for select using (true);
+
+create policy "Users can delete their videos" on public.videos
+  for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `react-native-video` dependency
- save uploaded post videos to the new `videos` table
- switch `VideoScreen` to use `react-native-video`
- document the new dependency in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684ab60e80cc8322ad46c6c03d7a49a6