### PR TITLE
Implement vertical video feed

### DIFF
--- a/app/components/VideoFeedItem.tsx
+++ b/app/components/VideoFeedItem.tsx
@@ -1,0 +1,92 @@
+import React, { useRef, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+import Video from 'react-native-video';
+import { colors } from '../styles/colors';
+
+export interface FeedVideo {
+  id: string;
+  video_url: string;
+  username: string;
+  caption: string;
+  localUri?: string;
+}
+
+interface Props {
+  video: FeedVideo;
+  isActive: boolean;
+  muted: boolean;
+  onToggleMute: () => void;
+}
+
+export default function VideoFeedItem({ video, isActive, muted, onToggleMute }: Props) {
+  const ref = useRef<Video>(null);
+
+  useEffect(() => {
+    if (!isActive) {
+      ref.current?.seek(0);
+    }
+  }, [isActive]);
+
+  return (
+    <View style={styles.container}>
+      <Video
+        ref={ref}
+        source={{ uri: video.localUri || video.video_url }}
+        style={styles.video}
+        resizeMode="cover"
+        repeat
+        paused={!isActive}
+        muted={muted}
+      />
+      <View style={styles.infoContainer}>
+        <Text style={styles.username}>@{video.username}</Text>
+        <Text style={styles.caption}>{video.caption}</Text>
+      </View>
+      <TouchableOpacity style={styles.muteButton} onPress={onToggleMute}>
+        <Text style={styles.muteText}>{muted ? 'Unmute' : 'Mute'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const { height, width } = Dimensions.get('window');
+
+const styles = StyleSheet.create({
+  container: {
+    width,
+    height,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'black',
+  },
+  video: {
+    position: 'absolute',
+    width,
+    height,
+  },
+  infoContainer: {
+    position: 'absolute',
+    bottom: 80,
+    left: 10,
+    paddingRight: 80,
+  },
+  username: {
+    color: colors.text,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  caption: {
+    color: colors.text,
+  },
+  muteButton: {
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: 10,
+    borderRadius: 20,
+  },
+  muteText: {
+    color: colors.text,
+  },
+});

--- a/bottomtabs/VideoScreen.js
+++ b/bottomtabs/VideoScreen.js
@@ -1,13 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { View, StyleSheet, Dimensions, FlatList } from 'react-native';
-import Video from 'react-native-video';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { View, StyleSheet, FlatList } from 'react-native';
+import * as FileSystem from 'expo-file-system';
+import VideoFeedItem from '../app/components/VideoFeedItem';
 
 import { supabase } from '../lib/supabase';
 import { colors } from '../app/styles/colors';
 
 export default function VideoScreen() {
   const [videos, setVideos] = useState([]);
+  const [cached, setCached] = useState({});
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [muted, setMuted] = useState(true);
   const viewabilityConfig = { viewAreaCoveragePercentThreshold: 80 };
   const onViewableItemsChanged = useRef(({ viewableItems }) => {
     if (viewableItems.length > 0) {
@@ -19,10 +22,17 @@ export default function VideoScreen() {
     const fetchVideos = async () => {
       const { data, error } = await supabase
         .from('videos')
-        .select('id, user_id, video_url, created_at')
+        .select('id, video_url, caption, profiles(username)')
         .order('created_at', { ascending: false });
+
       if (!error && data) {
-        setVideos(data);
+        const mapped = data.map(v => ({
+          id: v.id,
+          video_url: v.video_url,
+          caption: v.caption || '',
+          username: v.profiles?.username || 'unknown',
+        }));
+        setVideos(mapped);
       } else {
         console.error('Failed to fetch videos', error);
       }
@@ -30,49 +40,60 @@ export default function VideoScreen() {
     fetchVideos();
   }, []);
 
-  const renderItem = ({ item, index }) => (
-    <View style={styles.videoContainer}>
-      <Video
-        source={{ uri: item.video_url }}
-        style={styles.video}
-        resizeMode="contain"
-        paused={currentIndex !== index}
-        repeat
-        muted={false}
+  const prefetch = useCallback(async url => {
+    if (!url || cached[url]) return;
+    try {
+      const fileUri = FileSystem.cacheDirectory + encodeURIComponent(url);
+      const info = await FileSystem.getInfoAsync(fileUri);
+      if (!info.exists) {
+        await FileSystem.downloadAsync(url, fileUri);
+      }
+      setCached(c => ({ ...c, [url]: fileUri }));
+    } catch (e) {
+      console.warn('Prefetch failed', e);
+    }
+  }, [cached]);
 
+  useEffect(() => {
+    if (videos[currentIndex + 1]) {
+      prefetch(videos[currentIndex + 1].video_url);
+    }
+  }, [currentIndex, videos, prefetch]);
+
+  const toggleMute = useCallback(() => setMuted(m => !m), []);
+
+  const renderItem = useCallback(
+    ({ item, index }) => (
+      <VideoFeedItem
+        video={{ ...item, localUri: cached[item.video_url] }}
+        isActive={currentIndex === index}
+        muted={muted}
+        onToggleMute={toggleMute}
       />
-    </View>
+    ),
+    [currentIndex, muted, cached, toggleMute],
   );
 
   return (
     <View style={styles.container}>
       <FlatList
         data={videos}
-        keyExtractor={(item) => item.id}
+        keyExtractor={item => item.id}
         renderItem={renderItem}
         pagingEnabled
         showsVerticalScrollIndicator={false}
         onViewableItemsChanged={onViewableItemsChanged.current}
         viewabilityConfig={viewabilityConfig}
+        windowSize={3}
+        removeClippedSubviews
       />
     </View>
   );
 }
 
-const { height } = Dimensions.get('window');
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-  },
-  videoContainer: {
-    height,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  video: {
-    width: '100%',
-    height: '100%',
   },
 });


### PR DESCRIPTION
## Summary
- add `VideoFeedItem` for rendering each video
- update `VideoScreen` to autoplay visible videos, preload upcoming videos, and overlay info

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ad502a5448322a71c98dda6138421