### PR TITLE
Implement listing view counter

### DIFF
--- a/app/screens/MarketListingDetailScreen.tsx
+++ b/app/screens/MarketListingDetailScreen.tsx
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ScrollView, Text, Image, StyleSheet, Button } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { colors } from '../styles/colors';
+import { supabase } from '../../lib/supabase';
 
 export default function MarketListingDetailScreen() {
   const { params } = useRoute<any>();
   const navigation = useNavigation<any>();
   const listing = params?.listing;
+
+  useEffect(() => {
+    if (listing?.id) {
+      supabase.rpc('increment_listing_views', { p_listing_id: listing.id });
+    }
+  }, [listing?.id]);
 
   if (!listing) return null;
 

--- a/sql/marketplace.sql
+++ b/sql/marketplace.sql
@@ -77,3 +77,13 @@ create trigger market_favorite_insert
 create trigger market_favorite_delete
   after delete on public.market_favorites
   for each row execute procedure public.decrement_listing_favorites();
+
+-- Simple helper to increment views when a listing is opened
+create or replace function public.increment_listing_views(p_listing_id uuid)
+returns void as $$
+begin
+  update public.market_listings
+  set views = views + 1
+  where id = p_listing_id;
+end;
+$$ language plpgsql;


### PR DESCRIPTION
## Summary
- increment views when a listing is opened
- add SQL helper to increment listing views

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad3bcdf0883229d947b088b8cb95b