### PR TITLE
Implement listing view counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql` **and** `sql/videos.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql` **and** `sql/marketplace.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles.
 
 
 
@@ -14,3 +14,5 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 
 
 With the database configured you can run `npm start` to launch the Expo app.
+
+The marketplace screens live under `app/screens` and use a dark theme. The primary background color is `#2c2c54` and interactive elements use the accent color `#0070f3`.

--- a/app/screens/MarketListingDetailScreen.tsx
+++ b/app/screens/MarketListingDetailScreen.tsx
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ScrollView, Text, Image, StyleSheet, Button } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { colors } from '../styles/colors';
+import { supabase } from '../../lib/supabase';
 
 export default function MarketListingDetailScreen() {
   const { params } = useRoute<any>();
   const navigation = useNavigation<any>();
   const listing = params?.listing;
+
+  useEffect(() => {
+    if (listing?.id) {
+      supabase.rpc('increment_listing_views', { p_listing_id: listing.id });
+    }
+  }, [listing?.id]);
 
   if (!listing) return null;
 

--- a/sql/marketplace.sql
+++ b/sql/marketplace.sql
@@ -77,3 +77,13 @@ create trigger market_favorite_insert
 create trigger market_favorite_delete
   after delete on public.market_favorites
   for each row execute procedure public.decrement_listing_favorites();
+
+-- Simple helper to increment views when a listing is opened
+create or replace function public.increment_listing_views(p_listing_id uuid)
+returns void as $$
+begin
+  update public.market_listings
+  set views = views + 1
+  where id = p_listing_id;
+end;
+$$ language plpgsql;


### PR DESCRIPTION
## Summary
- increment views when a listing is opened
- add SQL helper to increment listing views
- add marketplace setup instructions to README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad3bcdf0883229d947b088b8cb95b