### PR TITLE
Add marketplace header component

### DIFF
--- a/app/components/MarketHeader.tsx
+++ b/app/components/MarketHeader.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+export default function MarketHeader() {
+  return (
+    <View style={styles.headerWrapper}>
+      <Text style={styles.title}>Market</Text>
+      <View style={styles.buttonRow}>
+        <TouchableOpacity style={styles.tabButton}>
+          <Text style={styles.tabText}>Voor jou</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.inactiveTab}>
+          <Text style={styles.inactiveText}>Verkopen</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.inactiveTab}>
+          <Text style={styles.inactiveText}>Categorieën</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerWrapper: {
+    backgroundColor: '#fff',
+    paddingTop: 50,
+    paddingHorizontal: 20,
+    paddingBottom: 10,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    marginTop: 15,
+    gap: 10,
+  },
+  tabButton: {
+    backgroundColor: '#e5edff',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+  },
+  inactiveTab: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+  },
+  tabText: {
+    color: '#0057ff',
+    fontWeight: '600',
+  },
+  inactiveText: {
+    color: '#000',
+    fontWeight: '500',
+  },
+});

--- a/app/screens/MarketHomeScreen.tsx
+++ b/app/screens/MarketHomeScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
+import MarketHeader from '../components/MarketHeader';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const BOTTOM_NAV_HEIGHT = SCREEN_HEIGHT * 0.1;
@@ -110,6 +111,7 @@ export default function MarketHomeScreen() {
 
   return (
     <View style={styles.container}>
+      <MarketHeader />
       <FlatList
         data={listings}
         keyExtractor={item => item.id}


### PR DESCRIPTION
## Summary
- create `MarketHeader` component
- show the new header on `MarketHomeScreen`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b10d7875c8322889a7922e86161b1