### PR TITLE
Add square preview card for new listings

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -7,8 +7,10 @@ import {
   Image,
   Dimensions,
   View,
+  Text,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../../AuthContext';
 import { supabase, MARKET_BUCKET } from '../../lib/supabase';
@@ -25,19 +27,49 @@ export default function CreateListingScreen() {
   const [title, setTitle] = useState('');
   const [price, setPrice] = useState('');
   const [image, setImage] = useState<string | null>(null);
+const [createdListing, setCreatedListing] = useState<any | null>(null);
+
+  const processImage = async (
+    asset: ImagePicker.ImagePickerAsset,
+  ): Promise<string> => {
+    const width = asset.width || 0;
+    const height = asset.height || 0;
+    const size = Math.min(width, height);
+    const result = await ImageManipulator.manipulateAsync(
+      asset.uri,
+      [
+        {
+          crop: {
+            originX: (width - size) / 2,
+            originY: (height - size) / 2,
+            width: size,
+            height: size,
+          },
+        },
+      ],
+      { compress: 0.9, format: ImageManipulator.SaveFormat.JPEG },
+    );
+    return result.uri;
+  };
 
   const pickFromGallery = async () => {
     const res = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
     });
-    if (!res.canceled) setImage(res.assets[0].uri);
+    if (!res.canceled) {
+      const uri = await processImage(res.assets[0]);
+      setImage(uri);
+    }
   };
 
   const takePhoto = async () => {
     const res = await ImagePicker.launchCameraAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
     });
-    if (!res.canceled) setImage(res.assets[0].uri);
+    if (!res.canceled) {
+      const uri = await processImage(res.assets[0]);
+      setImage(uri);
+    }
   };
 
   const uploadImage = async (uri: string) => {
@@ -52,22 +84,27 @@ export default function CreateListingScreen() {
   };
 
   const handleCreate = async () => {
-    if (!user) return;
+    if (!user || !title || !price || !image) return;
+
     let publicUrl: string | null = null;
-    if (image) {
-      try {
-        publicUrl = await uploadImage(image);
-      } catch (err) {
-        console.error('Image upload failed', err);
-      }
+    try {
+      publicUrl = await uploadImage(image);
+    } catch (err) {
+      console.error('Image upload failed', err);
     }
-    await supabase.from('market_listings').insert({
-      user_id: user.id,
-      title,
-      price: price ? parseFloat(price) : null,
-      image_urls: publicUrl ? [publicUrl] : [],
-    });
-    navigation.goBack();
+
+    const { data } = await supabase
+      .from('market_listings')
+      .insert({
+        user_id: user.id,
+        title,
+        price: parseFloat(price),
+        image_urls: publicUrl ? [publicUrl] : [],
+      })
+      .select('*')
+      .single();
+
+    setCreatedListing(data);
   };
 
   return (
@@ -79,7 +116,9 @@ export default function CreateListingScreen() {
         <Button title="Take Photo" onPress={takePhoto} color={colors.accent} />
         <Button title="Pick Image" onPress={pickFromGallery} color={colors.accent} />
       </View>
-      {image && <Image source={{ uri: image }} style={styles.image} />}
+      {image && (
+        <Image source={{ uri: image }} style={styles.image} resizeMode="cover" />
+      )}
       <TextInput
         placeholder="Title"
         placeholderTextColor={colors.muted}
@@ -96,6 +135,26 @@ export default function CreateListingScreen() {
         keyboardType="numeric"
       />
       <Button title="Create Listing" onPress={handleCreate} color={colors.accent} />
+
+      {createdListing && (
+        <View style={styles.previewCard}>
+          {createdListing.image_urls?.[0] && (
+            <Image
+              source={{ uri: createdListing.image_urls[0] }}
+              style={styles.previewImage}
+              resizeMode="cover"
+            />
+          )}
+          <Text style={styles.previewPrice}>{`€ ${createdListing.price ?? ''}`}</Text>
+          <Text
+            style={styles.previewTitle}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {createdListing.title}
+          </Text>
+        </View>
+      )}
     </ScrollView>
   );
 }
@@ -114,7 +173,19 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     marginTop: 10,
   },
-  image: { width: '100%', height: 200, marginTop: 10, borderRadius: 6 },
+  image: { width: '100%', aspectRatio: 1, marginTop: 10, borderRadius: 6 },
+  previewCard: {
+    backgroundColor: '#333',
+    padding: 10,
+    borderRadius: 8,
+    marginTop: 20,
+    marginBottom: 12,
+    width: '48%',
+    alignSelf: 'center',
+  },
+  previewImage: { width: '100%', aspectRatio: 1, borderRadius: 6 },
+  previewPrice: { color: colors.accent, fontSize: 18, marginTop: 6 },
+  previewTitle: { color: colors.text, marginTop: 4 },
   buttonRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-screens": "~4.10.0",
     "react-native-tab-view": "^4.0.12",
     "stream-browserify": "^3.0.0",
+    "expo-image-manipulator": "~11.4.0",
     "util": "^0.12.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- crop selected listing images to centered square with Expo ImageManipulator
- show image preview with square aspect ratio before creation
- keep listing preview card styles consistent with Market tab

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b529dbb3c832280b5003caa0942ce