### PR TITLE
Add listing placeholder cards

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -32,8 +32,8 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
   const processImage = async (
     asset: ImagePicker.ImagePickerAsset,
   ): Promise<string> => {
-    const width = asset.width || 0;
-    const height = asset.height || 0;
+    const width = asset.width || 1;
+    const height = asset.height || 1;
     const size = Math.min(width, height);
     const result = await ImageManipulator.manipulateAsync(
       asset.uri,
@@ -78,7 +78,7 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
     const path = `${user!.id}-${Date.now()}.${ext}`;
     const resp = await fetch(uri);
     const blob = await resp.blob();
-    const { error } = await supabase.storage.from(MARKET_BUCKET).upload(path, blob);
+    const { error } = await supabase.storage.from(MARKET_BUCKET).upload(path, blob, { upsert: true });
     if (error) throw error;
     return supabase.storage.from(MARKET_BUCKET).getPublicUrl(path).data.publicUrl;
 

--- a/app/screens/MarketHomeScreen.tsx
+++ b/app/screens/MarketHomeScreen.tsx
@@ -77,9 +77,26 @@ export default function MarketHomeScreen() {
     <View style={styles.container}>
       <MarketHeader />
       {listings.length === 0 ? (
-        <View style={styles.emptyWrapper}>
-          <Text style={styles.emptyText}>No listings yet</Text>
-        </View>
+        <FlatList
+          data={[1, 2, 3, 4, 5, 6]}
+          keyExtractor={item => item.toString()}
+          renderItem={() => (
+            <View style={styles.placeholderCard}>
+              <View style={styles.placeholderImage} />
+              <View style={styles.placeholderLine} />
+              <View style={styles.placeholderLineShort} />
+            </View>
+          )}
+          numColumns={2}
+          columnWrapperStyle={{ justifyContent: 'space-between' }}
+          contentContainerStyle={{ padding: 10 }}
+          showsVerticalScrollIndicator={false}
+          ListFooterComponent={
+            <View style={styles.emptyWrapper}>
+              <Text style={styles.emptyText}>No listings yet</Text>
+            </View>
+          }
+        />
       ) : (
         <FlatList
           data={listings}
@@ -131,4 +148,30 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   emptyText: { color: colors.text, marginTop: 20 },
+  placeholderCard: {
+    backgroundColor: '#333',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 12,
+    width: '48%',
+  },
+  placeholderImage: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: 6,
+    backgroundColor: '#555',
+  },
+  placeholderLine: {
+    height: 18,
+    backgroundColor: '#555',
+    borderRadius: 4,
+    marginTop: 6,
+  },
+  placeholderLineShort: {
+    height: 14,
+    backgroundColor: '#555',
+    borderRadius: 4,
+    marginTop: 4,
+    width: '80%',
+  },
 });


### PR DESCRIPTION
## Summary
- show placeholder cards when there are no listings
- style placeholder cards and lines for MarketHomeScreen
- crop images before upload and allow updating listing images

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bce07628c8322ad4153074345dbd6