### PR TITLE
Show placeholder after creating listing

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -96,7 +96,13 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
       .single();
 
     setCreatedListing(data);
-    navigation.goBack();
+    navigation.navigate('MarketHome', {
+      placeholderListing: {
+        id: data?.id,
+        title: data?.title,
+        price: data?.price,
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- show a temporary listing card on the home screen after creating a listing
- navigate back to `MarketHome` with the placeholder data

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c319518708322b4a5a26c6ec4d751