### PR TITLE
Implement placeholder listing on MarketHome

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -83,6 +83,7 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
         id: Date.now().toString(),
         title,
         price: parseFloat(price),
+        isPlaceholder: true,
       },
     });
 

--- a/app/screens/MarketHomeScreen.tsx
+++ b/app/screens/MarketHomeScreen.tsx
@@ -38,6 +38,7 @@ interface Listing {
   views?: number | null;
   favorites?: number | null;
   search_index?: string | null;
+  isPlaceholder?: boolean;
 }
 
 export default function MarketHomeScreen() {
@@ -71,8 +72,12 @@ export default function MarketHomeScreen() {
 
   const renderItem = ({ item }: { item: Listing }) => (
     <TouchableOpacity
-      style={styles.card}
-      onPress={() => navigation.navigate('ListingDetail', { listing: item })}
+      style={[styles.card, item.isPlaceholder && styles.placeholderOpacity]}
+      onPress={() =>
+        !item.isPlaceholder &&
+        navigation.navigate('ListingDetail', { listing: item })
+      }
+      activeOpacity={item.isPlaceholder ? 1 : 0.2}
     >
       {item.image_urls && item.image_urls[0] ? (
         <Image
@@ -196,5 +201,8 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     marginTop: 4,
     width: '80%',
+  },
+  placeholderOpacity: {
+    opacity: 0.5,
   },
 });


### PR DESCRIPTION
## Summary
- show placeholder listing immediately after pressing **Create Listing**
- disable navigation on the temporary card and fade it slightly

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules and missing types)*

------
https://chatgpt.com/codex/tasks/task_e_684c45225c4083228cff43e34700d9f3