### PR TITLE
Implement placeholder listing on MarketHome

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -63,9 +63,9 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
     }
   };
 
-  const uploadImage = async (uri: string) => {
+  const uploadImage = async (uri: string, userId: string) => {
     const ext = uri.split('.').pop();
-    const path = `${user!.id}-${Date.now()}.${ext}`;
+    const path = `${userId}-${Date.now()}.${ext}`;
     const resp = await fetch(uri);
     const blob = await resp.blob();
     const { error } = await supabase.storage.from(MARKET_BUCKET).upload(path, blob, { upsert: true });
@@ -83,12 +83,13 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
         id: Date.now().toString(),
         title,
         price: parseFloat(price),
+        isPlaceholder: true,
       },
     });
 
     let publicUrl: string | null = null;
     try {
-      publicUrl = await uploadImage(image);
+      publicUrl = await uploadImage(image, user.id);
     } catch (err) {
       console.error('Image upload failed', err);
     }

--- a/app/screens/MarketHomeScreen.tsx
+++ b/app/screens/MarketHomeScreen.tsx
@@ -38,6 +38,7 @@ interface Listing {
   views?: number | null;
   favorites?: number | null;
   search_index?: string | null;
+  isPlaceholder?: boolean;
 }
 
 export default function MarketHomeScreen() {
@@ -71,8 +72,12 @@ export default function MarketHomeScreen() {
 
   const renderItem = ({ item }: { item: Listing }) => (
     <TouchableOpacity
-      style={styles.card}
-      onPress={() => navigation.navigate('ListingDetail', { listing: item })}
+      style={[styles.card, item.isPlaceholder && styles.placeholderOpacity]}
+      onPress={() =>
+        !item.isPlaceholder &&
+        navigation.navigate('ListingDetail', { listing: item })
+      }
+      activeOpacity={item.isPlaceholder ? 1 : 0.2}
     >
       {item.image_urls && item.image_urls[0] ? (
         <Image
@@ -196,5 +201,8 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     marginTop: 4,
     width: '80%',
+  },
+  placeholderOpacity: {
+    opacity: 0.5,
   },
 });


### PR DESCRIPTION
## Summary
- show placeholder listing immediately after pressing **Create Listing**
- disable navigation on the temporary card and fade it slightly
- tweak `uploadImage` to accept a user ID

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules and missing types)*

------
https://chatgpt.com/codex/tasks/task_e_684c45225c4083228cff43e34700d9f3