### PR TITLE
Add listing preview card

### DIFF
--- a/app/components/ListingPreviewCard.tsx
+++ b/app/components/ListingPreviewCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Image, Text, StyleSheet } from 'react-native';
+import { colors } from '../styles/colors';
+
+interface ListingPreviewCardProps {
+  imageUri: string;
+  title: string;
+  price: string;
+}
+
+export default function ListingPreviewCard({
+  imageUri,
+  title,
+  price,
+}: ListingPreviewCardProps) {
+  const formattedPrice = price ? `€${parseFloat(price).toFixed(2)}` : '';
+
+  return (
+    <View style={styles.card}>
+      <Image source={{ uri: imageUri }} style={styles.image} resizeMode="cover" />
+      <View style={styles.overlay} pointerEvents="none">
+        <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
+          {title}
+        </Text>
+        <Text style={styles.price}>{formattedPrice}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: '60%',
+    aspectRatio: 1,
+    alignSelf: 'center',
+    borderRadius: 12,
+    overflow: 'hidden',
+    marginTop: 20,
+    marginBottom: 12,
+    backgroundColor: '#333',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  overlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    padding: 8,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  title: { color: colors.text, fontWeight: '600' },
+  price: { color: colors.accent, fontSize: 16, marginTop: 2 },
+});

--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -1,19 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   ScrollView,
   TextInput,
   Button,
   StyleSheet,
-  Image,
   Dimensions,
   View,
   Text,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useNavigation } from '@react-navigation/native';
-import { useAuth } from '../../AuthContext';                    
+import { useAuth } from '../../AuthContext';
 import { supabase, MARKET_BUCKET } from '../../lib/supabase';
 import { colors } from '../styles/colors';
+import ListingPreviewCard from '../components/ListingPreviewCard';
 
 
 
@@ -29,11 +29,6 @@ export default function CreateListingScreen() {
   const [title, setTitle] = useState('');
   const [price, setPrice] = useState('');
   const [image, setImage] = useState<string | null>(null);
-const [createdListing, setCreatedListing] = useState<any | null>(null);
-
-  useEffect(() => {
-    console.log('image state changed', image);
-  }, [image]);
 
   const processImage = async (
     asset: ImagePicker.ImagePickerAsset,
@@ -111,7 +106,7 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
         <Button title="Pick Image" onPress={pickFromGallery} color={colors.accent} />
       </View>
       {image && (
-        <Image source={{ uri: image }} style={styles.image} resizeMode="cover" />
+        <ListingPreviewCard imageUri={image} title={title} price={price} />
       )}
       <TextInput
         placeholder="Title"
@@ -129,26 +124,6 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
         keyboardType="numeric"
       />
       <Button title="Create Listing" onPress={handleCreate} color={colors.accent} />
-
-      {createdListing && (
-        <View style={styles.previewCard}>
-          {createdListing.image_urls?.[0] && (
-            <Image
-              source={{ uri: createdListing.image_urls[0] }}
-              style={styles.previewImage}
-              resizeMode="cover"
-            />
-          )}
-          <Text style={styles.previewPrice}>{`€ ${createdListing.price ?? ''}`}</Text>
-          <Text
-            style={styles.previewTitle}
-            numberOfLines={1}
-            ellipsizeMode="tail"
-          >
-            {createdListing.title}
-          </Text>
-        </View>
-      )}
     </ScrollView>
   );
 }
@@ -167,21 +142,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     marginTop: 10,
   },
-  image: { width: '100%', aspectRatio: 1, marginTop: 10, borderRadius: 6 },
-
-  previewCard: {
-    backgroundColor: '#333',
-    padding: 10,
-    borderRadius: 8,
-    marginTop: 20,
-    marginBottom: 12,
-    width: '48%',
-    alignSelf: 'center',
-
-  },
-  previewImage: { width: '100%', aspectRatio: 1, borderRadius: 6 },
-  previewPrice: { color: colors.accent, fontSize: 18, marginTop: 6 },
-  previewTitle: { color: colors.text, marginTop: 4 },
   buttonRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',


### PR DESCRIPTION
## Summary
- show a live preview of the selected marketplace photo
- preview updates as title and price change

## Testing
- `npx tsc --noEmit` *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a1c41148322ad94718377f4cc7d