### PR TITLE
Fix Supabase public URL retrieval

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -70,15 +70,15 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
     const blob = await resp.blob();
     const { error } = await supabase.storage.from(MARKET_BUCKET).upload(path, blob, { upsert: true });
     if (error) throw error;
-    const { data, error: publicUrlError } = supabase.storage
+    const { data } = supabase.storage
       .from(MARKET_BUCKET)
       .getPublicUrl(path);
 
-    if (publicUrlError || !data?.publicURL) {
+    if (!data.publicUrl) {
       throw new Error('Failed to retrieve public URL');
     }
 
-    return data.publicURL;
+    return data.publicUrl;
 
 
   };

--- a/app/screens/EditListingScreen.tsx
+++ b/app/screens/EditListingScreen.tsx
@@ -61,16 +61,15 @@ export default function EditListingScreen() {
       const blob = await resp.blob();
       const { error } = await supabase.storage.from(MARKET_BUCKET).upload(path, blob, { upsert: true });
       if (!error) {
-              const { data, error: publicUrlError } = supabase.storage
-        .from(MARKET_BUCKET)
-        .getPublicUrl(path);
+        const { data } = supabase.storage
+          .from(MARKET_BUCKET)
+          .getPublicUrl(path);
 
-      if (publicUrlError || !data?.publicURL) {
-        throw new Error('Failed to retrieve public URL');
-      }
+        if (!data.publicUrl) {
+          throw new Error('Failed to retrieve public URL');
+        }
 
-url = data.publicURL;
-
+        url = data.publicUrl;
       }
     }
     await supabase


### PR DESCRIPTION
## Summary
- fix case of `publicUrl` when creating or editing market listings so the image URL is saved correctly

## Testing
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d5658efa08322a261dd606842482a