### PR TITLE
Fix public URL property check

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -83,11 +83,11 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
       .from(BUCKET)
       .getPublicUrl(path);
 
-    if (urlError || !data?.publicUrl) {
+    if (urlError || !data?.publicURL) {
       throw new Error('Failed to retrieve public URL');
     }
 
-    return data.publicUrl;
+    return data.publicURL;
   };
 
 


### PR DESCRIPTION
## Summary
- ensure CreateListingScreen checks `data.publicURL` from Supabase

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684eaefcfab883229cb5d11355db76db