### PR TITLE
Fix Supabase publicURL references

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -83,11 +83,11 @@ const [createdListing, setCreatedListing] = useState<any | null>(null);
       .from(BUCKET)
       .getPublicUrl(path);
 
-    if (urlError || !data?.publicUrl) {
+    if (urlError || !data?.publicURL) {
       throw new Error('Failed to retrieve public URL');
     }
 
-    return data.publicUrl;
+    return data.publicURL;
   };
 
 

--- a/app/screens/EditListingScreen.tsx
+++ b/app/screens/EditListingScreen.tsx
@@ -65,11 +65,11 @@ export default function EditListingScreen() {
           .from(MARKET_BUCKET)
           .getPublicUrl(path);
 
-        if (!data.publicUrl) {
+        if (!data.publicURL) {
           throw new Error('Failed to retrieve public URL');
         }
 
-        url = data.publicUrl;
+        url = data.publicURL;
       }
     }
     await supabase

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -272,7 +272,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
           .from('reply-videos')
           .upload(path, blob);
         if (!uploadError) {
-          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicURL;
         }
       } catch (e) {
         console.error('Video upload failed', e);
@@ -489,7 +489,7 @@ const HomeScreen = forwardRef<HomeScreenRef, HomeScreenProps>(
         if (!uploadError) {
           uploadedVideoUrl = supabase.storage
             .from('post-videos')
-            .getPublicUrl(path).data.publicUrl;
+            .getPublicUrl(path).data.publicURL;
         }
       } catch (e) {
         console.error('Video upload failed', e);

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -482,7 +482,7 @@ export default function PostDetailScreen() {
           .from('reply-videos')
           .upload(path, blob);
         if (!uploadError) {
-          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicURL;
         }
       } catch (e) {
         console.error('Video upload failed', e);

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -280,7 +280,7 @@ export default function ProfileScreen() {
           .from('reply-videos')
           .upload(path, blob);
         if (!uploadError) {
-          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicURL;
         }
       } catch (e) {
         console.error('Video upload failed', e);

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -520,7 +520,7 @@ export default function ReplyDetailScreen() {
           .from('reply-videos')
           .upload(path, blob);
         if (!uploadError) {
-          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicURL;
         }
       } catch (e) {
         console.error('Video upload failed', e);


### PR DESCRIPTION
## Summary
- ensure all uploads check `data.publicURL` when retrieving links

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684eaefcfab883229cb5d11355db76db