### PR TITLE
Update image upload result usage

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -86,11 +86,11 @@ export default function CreateListingScreen() {
       .from(BUCKET)
       .getPublicUrl(path);
 
-    if (urlError || !data?.publicURL) {
+    if (urlError || !data?.publicUrl) {
       throw new Error('Failed to retrieve public URL');
     }
 
-    return data.publicURL;
+    return data.publicUrl;
   };
 
   const handleCreate = async () => {
@@ -115,7 +115,7 @@ export default function CreateListingScreen() {
             user_id: user.id,
             title,
             price: parseFloat(price),
-            image_url: publicUrl,
+            image_urls: [publicUrl],
           },
         ])
         .select('*')


### PR DESCRIPTION
## Summary
- use `data.publicUrl` in `uploadImage`
- store new listing images in `image_urls` array

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684fc63bd90c8322a64a0a538bc7cd4d