### PR TITLE
Fix listing creation navigation

### DIFF
--- a/app/screens/CreateListingScreen.tsx
+++ b/app/screens/CreateListingScreen.tsx
@@ -96,15 +96,6 @@ export default function CreateListingScreen() {
   const handleCreate = async () => {
     if (!user || !title || !price || !image) return;
 
-    navigation.navigate('MarketHome', {
-      placeholderListing: {
-        id: Date.now().toString(),
-        title,
-        price: parseFloat(price),
-        isPlaceholder: true,
-      },
-    });
-
     try {
       const publicUrl = await uploadImage(image, user.id);
 
@@ -124,6 +115,7 @@ export default function CreateListingScreen() {
       if (error) throw error;
 
       setCreatedListing(data);
+      navigation.navigate('MarketHome');
     } catch (err) {
       console.error('Image or Listing creation failed:', err);
     }


### PR DESCRIPTION
## Summary
- navigate back to MarketHome only after the new listing is inserted

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684fd946e2b0832293873d5075769d17