### PR TITLE
Add delete listing support

### DIFF
--- a/app/screens/MarketHomeScreen.tsx
+++ b/app/screens/MarketHomeScreen.tsx
@@ -71,6 +71,13 @@ export default function MarketHomeScreen() {
     }
   }, [route.params?.placeholderListing]);
 
+  useEffect(() => {
+    if (route.params?.deletedListingId) {
+      setListings(prev => prev.filter(l => l.id !== route.params.deletedListingId));
+      navigation.setParams({ deletedListingId: undefined });
+    }
+  }, [route.params?.deletedListingId]);
+
   const renderItem = ({ item }: { item: Listing }) => (
     <TouchableOpacity
       style={[styles.card, item.isPlaceholder && styles.placeholderOpacity]}


### PR DESCRIPTION
## Summary
- add delete button and confirmation modal on listing detail screen
- allow MarketHome to remove deleted listing when returning from detail

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6851281308708322abb61a5d7e4a102c