### PR TITLE
Restore For You feed

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -68,12 +68,23 @@ function PostCard({
       <View style={styles.post}>
         {showThreadLine && <View style={styles.threadLine} pointerEvents="none" />}
         {isOwner && (
-          <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
+          <TouchableOpacity
+            onPress={e => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            style={styles.deleteButton}
+          >
             <Text style={styles.deleteText}>X</Text>
           </TouchableOpacity>
         )}
         <View style={styles.row}>
-          <TouchableOpacity onPress={onProfilePress}>
+          <TouchableOpacity
+            onPress={e => {
+              e.stopPropagation();
+              onProfilePress();
+            }}
+          >
             {avatarUri ? (
               <Image source={{ uri: avatarUri }} style={styles.avatar} />
             ) : (
@@ -109,11 +120,23 @@ function PostCard({
             )}
           </View>
         </View>
-        <TouchableOpacity style={styles.replyCountContainer} onPress={onOpenReplies}>
+        <TouchableOpacity
+          style={styles.replyCountContainer}
+          onPress={e => {
+            e.stopPropagation();
+            onOpenReplies();
+          }}
+        >
           <Ionicons name="chatbubble-outline" size={18} color={colors.accent} style={{ marginRight: 2 }} />
           <Text style={styles.replyCountLarge}>{replyCount}</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.likeContainer} onPress={toggleLike}>
+        <TouchableOpacity
+          style={styles.likeContainer}
+          onPress={e => {
+            e.stopPropagation();
+            toggleLike();
+          }}
+        >
           <Ionicons name={liked ? 'heart' : 'heart-outline'} size={18} color="red" style={{ marginRight: 2 }} />
           <Text style={[styles.likeCountLarge, liked && styles.likedLikeCount]}>{likeCount}</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- expose `HomeScreenRef` interface for imperative actions
- attach FlatList ref with virtualization options
- match For You feed background color with Following feed
- fix PostCard import so posts render correctly
- dedupe posts when fetching or posting to avoid duplicate key warnings
- show reply count again and ensure tapping counts or avatar doesn’t open detail
- avoid crash when profile is null by gating early and optional chaining

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6852ab6dd4d883229ac91fdb8c288a00