### PR TITLE
Restore For You feed

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -68,12 +68,23 @@ function PostCard({
       <View style={styles.post}>
         {showThreadLine && <View style={styles.threadLine} pointerEvents="none" />}
         {isOwner && (
-          <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
+          <TouchableOpacity
+            onPress={e => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            style={styles.deleteButton}
+          >
             <Text style={styles.deleteText}>X</Text>
           </TouchableOpacity>
         )}
         <View style={styles.row}>
-          <TouchableOpacity onPress={onProfilePress}>
+          <TouchableOpacity
+            onPress={e => {
+              e.stopPropagation();
+              onProfilePress();
+            }}
+          >
             {avatarUri ? (
               <Image source={{ uri: avatarUri }} style={styles.avatar} />
             ) : (
@@ -109,11 +120,23 @@ function PostCard({
             )}
           </View>
         </View>
-        <TouchableOpacity style={styles.replyCountContainer} onPress={onOpenReplies}>
+        <TouchableOpacity
+          style={styles.replyCountContainer}
+          onPress={e => {
+            e.stopPropagation();
+            onOpenReplies();
+          }}
+        >
           <Ionicons name="chatbubble-outline" size={18} color={colors.accent} style={{ marginRight: 2 }} />
           <Text style={styles.replyCountLarge}>{replyCount}</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.likeContainer} onPress={toggleLike}>
+        <TouchableOpacity
+          style={styles.likeContainer}
+          onPress={e => {
+            e.stopPropagation();
+            toggleLike();
+          }}
+        >
           <Ionicons name={liked ? 'heart' : 'heart-outline'} size={18} color="red" style={{ marginRight: 2 }} />
           <Text style={[styles.likeCountLarge, liked && styles.likedLikeCount]}>{likeCount}</Text>
         </TouchableOpacity>

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,6 +1,11 @@
 // ✅ FIXED: HomeScreen.tsx with anti-jitter logic fully restored
 import React, {
-  useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
 } from 'react';
 import {
   View,
@@ -10,35 +15,179 @@ import {
   StyleSheet,
   Button,
   Alert,
+  Image,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
   ActivityIndicator,
 } from 'react-native';
+import { Video } from 'expo-av';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import { useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useAuth } from '../../contexts/AuthContext';
-import { usePostStore } from '../contexts/PostStoreContext';
-import { PostCard, Post } from '../components/PostCard';
+import { useAuth } from '../../AuthContext';
+import PostCard, { Post } from '../components/PostCard';
+import { colors } from '../styles/colors';
+import { replyEvents } from '../replyEvents';
+
+export interface HomeScreenRef {
+  createPost: (
+    content: string,
+    image?: string,
+    video?: string,
+  ) => Promise<void>;
+  scrollToTop: () => void;
+}
 
 const STORAGE_KEY = 'cached_posts';
 const PAGE_SIZE = 10;
 
-const HomeScreen = forwardRef(({ hideInput }, ref) => {
+const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
+  ({ hideInput }, ref) => {
   const navigation = useNavigation();
-  const { user, profile, updatePost, mergeLiked } = usePostStore();
+  const { user, profile } = useAuth()!;
   const [postText, setPostText] = useState('');
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const skipNextFetch = useRef(false);
+  const listRef = useRef<FlatList>(null);
+  const [replyModalVisible, setReplyModalVisible] = useState(false);
+  const [activePostId, setActivePostId] = useState<string | null>(null);
+  const [replyText, setReplyText] = useState('');
+  const [replyImage, setReplyImage] = useState<string | null>(null);
+  const [replyVideo, setReplyVideo] = useState<string | null>(null);
 
-  if (!user) {
+  if (!user || !profile) {
     return (
       <View style={styles.container}>
         <Text style={{ color: 'white', padding: 20 }}>Loading...</Text>
       </View>
     );
   }
+
+  const dedupeById = (arr: Post[]): Post[] => {
+    const seen = new Set<string>();
+    const result: Post[] = [];
+    for (const item of arr) {
+      if (!seen.has(item.id)) {
+        result.push(item);
+        seen.add(item.id);
+      }
+    }
+    return result;
+  };
+
+  const updateCachedPost = async (
+    id: string,
+    updated: Partial<Post>,
+  ): Promise<void> => {
+    try {
+      const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!stored) return;
+      const arr = JSON.parse(stored);
+      const newArr = arr.map((p: Post) => (p.id === id ? { ...p, ...updated } : p));
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(newArr));
+    } catch (e) {
+      console.error('Failed to update cached posts', e);
+    }
+  };
+
+  const openReplyModal = (postId: string) => {
+    setActivePostId(postId);
+    setReplyText('');
+    setReplyImage(null);
+    setReplyVideo(null);
+    setReplyModalVisible(true);
+  };
+
+  const pickReplyImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setReplyImage(`data:image/jpeg;base64,${base64}`);
+      setReplyVideo(null);
+    }
+  };
+
+  const pickReplyVideo = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.size && info.size > 20 * 1024 * 1024) {
+        Alert.alert('Video too large', 'Please select a video under 20MB.');
+        return;
+      }
+      setReplyVideo(uri);
+      setReplyImage(null);
+    }
+  };
+
+  const handleReplySubmit = async () => {
+    if (!activePostId || (!replyText.trim() && !replyImage && !replyVideo) || !profile) {
+      setReplyModalVisible(false);
+      return;
+    }
+
+    setReplyModalVisible(false);
+
+    const post = posts.find(p => p.id === activePostId);
+    const newCount = (post?.reply_count ?? 0) + 1;
+    setPosts(prev =>
+      prev.map(p =>
+        p.id === activePostId ? { ...p, reply_count: newCount } : p,
+      ),
+    );
+    updateCachedPost(activePostId, { reply_count: newCount });
+
+    let uploadedUrl: string | null = null;
+    if (replyVideo) {
+      try {
+        const ext = replyVideo.split('.').pop() || 'mp4';
+        const path = `${profile.id}-${Date.now()}.${ext}`;
+        const resp = await fetch(replyVideo);
+        const blob = await resp.blob();
+        const { error: uploadError } = await supabase.storage
+          .from('reply-videos')
+          .upload(path, blob);
+        if (!uploadError) {
+          uploadedUrl = supabase.storage.from('reply-videos').getPublicUrl(path).data.publicUrl;
+        }
+      } catch (e) {
+        console.error('Video upload failed', e);
+      }
+    }
+
+    const { error } = await supabase.from('replies').insert({
+      post_id: activePostId,
+      parent_id: null,
+      user_id: profile.id,
+      content: replyText,
+      image_url: replyImage,
+      video_url: uploadedUrl,
+      username: profile.name || profile.username,
+    });
+    if (error) {
+      console.error('Reply failed', error.message);
+    } else {
+      replyEvents.emit('replyAdded', activePostId);
+    }
+
+    setReplyText('');
+    setReplyImage(null);
+    setReplyVideo(null);
+  };
 
   const fetchPosts = useCallback(async (offset = 0, append = false) => {
     try {
@@ -54,8 +203,14 @@ const HomeScreen = forwardRef(({ hideInput }, ref) => {
       if (error) throw error;
 
       if (data) {
-        setPosts(prev => append ? [...prev, ...data] : data);
-        await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+        setPosts(prev => {
+          const combined = append ? [...prev, ...data] : data;
+          const unique = dedupeById(combined);
+          AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(unique)).catch(
+            () => {},
+          );
+          return unique;
+        });
       }
     } catch (e) {
       console.error('Failed to fetch posts', e);
@@ -71,7 +226,7 @@ const HomeScreen = forwardRef(({ hideInput }, ref) => {
     if (stored) {
       try {
         const cached = JSON.parse(stored);
-        setPosts(cached);
+        setPosts(dedupeById(cached));
         loadedFromCache = true;
       } catch (e) {
         console.error('Failed to parse cached posts', e);
@@ -91,35 +246,69 @@ const HomeScreen = forwardRef(({ hideInput }, ref) => {
     loadCached();
   }, []);
 
-  const handlePost = async () => {
-    if (!postText.trim()) return;
+  useEffect(() => {
+    const onReplyAdded = (postId: string) => {
+      setPosts(prev => {
+        const updated = prev.map(p => {
+          if (p.id === postId) {
+            const count = (p.reply_count ?? 0) + 1;
+            updateCachedPost(postId, { reply_count: count });
+            return { ...p, reply_count: count };
+          }
+          return p;
+        });
+        return updated;
+      });
+    };
+    replyEvents.on('replyAdded', onReplyAdded);
+    return () => {
+      replyEvents.off('replyAdded', onReplyAdded);
+    };
+  }, []);
+
+  const createPost = async (
+    content: string,
+    image?: string,
+    video?: string,
+  ) => {
+    if (!content.trim() || !profile) return;
     skipNextFetch.current = true;
 
     const newPost: Post = {
       id: `temp-${Date.now()}`,
-      content: postText,
+      content,
       user_id: user.id,
       created_at: new Date().toISOString(),
       like_count: 0,
       reply_count: 0,
       username: profile.username,
-      image_url: null,
-      video_url: null,
+      image_url: image ?? null,
+      video_url: video ?? null,
       profiles: profile,
     };
 
-    setPosts(prev => [newPost, ...prev]);
-    setPostText('');
+    setPosts(prev => dedupeById([newPost, ...prev]));
 
-    const { data, error } = await supabase.from('posts').insert({
-      content: postText,
-      user_id: user.id,
-      username: profile.username,
-    }).select().single();
+    const { data, error } = await supabase
+      .from('posts')
+      .insert({
+        content,
+        user_id: user.id,
+        username: profile.username,
+        image_url: image ?? null,
+        video_url: video ?? null,
+      })
+      .select()
+      .single();
 
     if (!error && data) {
-      setPosts(prev => prev.map(p => (p.id === newPost.id ? data : p)));
+      setPosts(prev => dedupeById(prev.map(p => (p.id === newPost.id ? data : p))));
     }
+  };
+
+  const handlePost = async () => {
+    await createPost(postText);
+    setPostText('');
   };
 
   const handleLike = async (postId: string) => {
@@ -131,6 +320,12 @@ const HomeScreen = forwardRef(({ hideInput }, ref) => {
     );
     await supabase.from('likes').insert({ post_id: postId, user_id: user.id });
   };
+
+  const scrollToTop = () => {
+    listRef.current?.scrollToOffset({ offset: 0, animated: true });
+  };
+
+  useImperativeHandle(ref, () => ({ createPost, scrollToTop }));
 
   return (
     <View style={styles.container}>
@@ -150,33 +345,109 @@ const HomeScreen = forwardRef(({ hideInput }, ref) => {
         <ActivityIndicator color="white" style={{ marginTop: 20 }} />
       ) : (
         <FlatList
+          ref={listRef}
           data={posts}
           keyExtractor={item => item.id}
-          renderItem={({ item }) => (
-            <PostCard
-              post={item}
-              isOwner={item.user_id === user.id}
-              onLike={() => handleLike(item.id)}
-              onPress={() => navigation.navigate('PostDetail', { post: item })}
-            />
-          )}
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingBottom: 20 }}
+          removeClippedSubviews={false}
+          initialNumToRender={10}
+          windowSize={5}
+          renderItem={({ item }) => {
+            const isMe = item.user_id === user.id;
+            const avatarUri = isMe
+              ? profile?.image_url ?? undefined
+              : item.profiles?.image_url ?? undefined;
+            const bannerUrl = isMe
+              ? profile?.banner_url ?? undefined
+              : item.profiles?.banner_url ?? undefined;
+            return (
+              <PostCard
+                post={item}
+                isOwner={isMe}
+                avatarUri={avatarUri}
+                bannerUrl={bannerUrl}
+                replyCount={item.reply_count ?? 0}
+                onLike={() => handleLike(item.id)}
+                onPress={() => navigation.navigate('PostDetail', { post: item })}
+                onProfilePress={() =>
+                  isMe
+                    ? navigation.navigate('Profile')
+                    : navigation.navigate('OtherUserProfile', { userId: item.user_id })
+                }
+                onDelete={() => {}}
+                onOpenReplies={() => openReplyModal(item.id)}
+              />
+            );
+          }}
           onEndReached={() => fetchPosts(posts.length, true)}
           onEndReachedThreshold={0.5}
           ListFooterComponent={loadingMore ? <ActivityIndicator /> : null}
         />
       )}
+      <Modal visible={replyModalVisible} animationType="slide" transparent>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.modalOverlay}
+        >
+          <View style={styles.modalContent}>
+            <TextInput
+              placeholder="Write a reply"
+              value={replyText}
+              onChangeText={setReplyText}
+              style={styles.input}
+              multiline
+            />
+            {replyImage && <Image source={{ uri: replyImage }} style={styles.preview} />}
+            {!replyImage && replyVideo && (
+              <Video
+                source={{ uri: replyVideo }}
+                style={styles.preview}
+                useNativeControls
+                isMuted
+                resizeMode="contain"
+              />
+            )}
+            <View style={styles.buttonRow}>
+              <Button title="Add Image" onPress={pickReplyImage} />
+              <Button title="Add Video" onPress={pickReplyVideo} />
+              <Button title="Post" onPress={handleReplySubmit} />
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </View>
   );
 });
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#000', padding: 10 },
+  container: { flex: 1, backgroundColor: colors.background, padding: 10 },
   input: {
     backgroundColor: '#111',
     color: '#fff',
     padding: 10,
     marginBottom: 10,
     borderRadius: 5,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: colors.background,
+    padding: 20,
+  },
+  preview: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
   },
 });
 


### PR DESCRIPTION
## Summary
- expose `HomeScreenRef` interface for imperative actions
- attach FlatList ref with virtualization options
- match For You feed background color with Following feed
- fix PostCard import so posts render correctly
- dedupe posts when fetching or posting to avoid duplicate key warnings
- show reply count again and ensure tapping counts or avatar doesn’t open detail
- avoid crash when profile is null by gating early and optional chaining
- add quick reply modal on For You feed
- persist reply count updates in AsyncStorage

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6852ab6dd4d883229ac91fdb8c288a00