### PR TITLE
Implement skip flag for replies

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -148,6 +148,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
 
     const post = posts.find(p => p.id === activePostId);
     const newCount = (post?.reply_count ?? 0) + 1;
+    skipNextFetch.current = true;
     setPosts(prev =>
       prev.map(p =>
         p.id === activePostId ? { ...p, reply_count: newCount } : p,


### PR DESCRIPTION
## Summary
- ensure `skipNextFetch` is set in `handleReplySubmit`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852d2cf336c8322811bae7a15703115