### PR TITLE
Implement skip flag for replies

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -148,6 +148,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
 
     const post = posts.find(p => p.id === activePostId);
     const newCount = (post?.reply_count ?? 0) + 1;
+    skipNextFetch.current = true;
     setPosts(prev =>
       prev.map(p =>
         p.id === activePostId ? { ...p, reply_count: newCount } : p,
@@ -186,7 +187,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
     if (error) {
       console.error('Reply failed', error.message);
     } else {
-      replyEvents.emit('replyAdded', activePostId);
+      replyEvents.emit('replyAdded', activePostId, true);
     }
 
     setReplyText('');
@@ -253,7 +254,8 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
   }, []);
 
   useEffect(() => {
-    const onReplyAdded = (postId: string) => {
+    const onReplyAdded = (postId: string, fromSelf?: boolean) => {
+      if (fromSelf) return;
       setPosts(prev => {
         const updated = prev.map(p => {
           if (p.id === postId) {

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -138,7 +138,8 @@ export default function ProfileScreen() {
   }, []);
 
   useEffect(() => {
-    const onReplyAdded = (postId: string) => {
+    const onReplyAdded = (postId: string, fromSelf?: boolean) => {
+      if (fromSelf) return;
       setReplyCounts(prev => {
         const updated = { ...prev, [postId]: (prev[postId] || 0) + 1 };
         AsyncStorage.setItem(COUNT_STORAGE_KEY, JSON.stringify(updated));
@@ -323,7 +324,7 @@ export default function ProfileScreen() {
         return counts;
       });
       initialize([{ id: data.id, like_count: 0 }]);
-      replyEvents.emit('replyAdded', activePostId);
+      replyEvents.emit('replyAdded', activePostId, true);
     } else if (error) {
       console.error('Reply failed', error.message);
     }


### PR DESCRIPTION
## Summary
- ensure `skipNextFetch` is set in `handleReplySubmit`
- avoid double increments on reply events

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852d2cf336c8322811bae7a15703115