### PR TITLE
Fix auth flicker

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -11,7 +11,7 @@ const Stack = createNativeStackNavigator();
 export default function Navigator() {
   const { user, loading } = useAuth()!;
 
-  if (loading) return null;
+  if (loading) return <LoadingScreen />;
 
   return (
     <Suspense fallback={<LoadingScreen />}>


### PR DESCRIPTION
## Summary
- avoid blank screen by showing a loader while auth session initializes
- recover session using async `getSession` and drop direct calls to `supabase.auth.user`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853d53c4c34832291b855329e6d591a