### PR TITLE
Fix auth flicker

### DIFF
--- a/AuthContext.tsx
+++ b/AuthContext.tsx
@@ -112,21 +112,41 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // 🔁 Refresh session on mount without flicker
   useEffect(() => {
+    let isMounted = true;
+
+    const init = async () => {
+      try {
+        // Prefer the async getSession API when available
+        const { data } = await (supabase.auth.getSession
+          ? supabase.auth.getSession()
+          : Promise.resolve({ data: { session: supabase.auth.session() } }));
+
+        const session = data?.session;
+        if (session?.user && isMounted) {
+          setUser(session.user);
+          await ensureProfile(session.user);
+        }
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    init();
+
     const { data: listener } = supabase.auth.onAuthStateChange(
       async (_event, session) => {
+        if (!isMounted) return;
         setUser(session?.user ?? null);
         if (session?.user) {
-          // Refresh or create the profile for consistent posting
           await ensureProfile(session.user);
         } else {
           setProfile(null);
         }
-        // Session has been resolved so loading can stop
-        setLoading(false);
       },
     );
 
     return () => {
+      isMounted = false;
       if (listener?.subscription) {
         listener.subscription.unsubscribe();
       } else {
@@ -137,7 +157,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const loadImage = async () => {
-      const authUser = user ?? supabase.auth.user();
+      const authUser = user;
       if (!authUser) return;
 
       const profileKey = `profile_image_uri_${authUser.id}`;
@@ -280,8 +300,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const setProfileImageUri = useCallback(async (uri: string | null): Promise<void> => {
     setProfileImageUriState(uri);
-    const authUser = supabase.auth.user();
-    const id = authUser?.id || user?.id;
+    const authUser = user ?? supabase.auth.session()?.user ?? null;
+    const id = authUser?.id;
     const key = id ? `profile_image_uri_${id}` : 'profile_image_uri';
 
     if (authUser) {
@@ -301,8 +321,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const setBannerImageUri = useCallback(async (uri: string | null): Promise<void> => {
     setBannerImageUriState(uri);
-    const authUser = supabase.auth.user();
-    const id = authUser?.id || user?.id;
+    const authUser = user ?? supabase.auth.session()?.user ?? null;
+    const id = authUser?.id;
     const key = id ? `banner_image_uri_${id}` : 'banner_image_uri';
 
     if (authUser) {
@@ -439,7 +459,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       .single();
 
     if (!error && data) {
-      const authUser = supabase.auth.user();
+      const authUser = user ?? supabase.auth.session()?.user ?? null;
       const meta = authUser?.user_metadata || {};
       const profileData = {
         ...data,

--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -11,7 +11,7 @@ const Stack = createNativeStackNavigator();
 export default function Navigator() {
   const { user, loading } = useAuth()!;
 
-  if (loading) return null;
+  if (loading) return <LoadingScreen />;
 
   return (
     <Suspense fallback={<LoadingScreen />}>

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -385,9 +385,14 @@ export default function ProfileScreen() {
       if (!error && data) {
         const list = data as Post[];
         setPosts(prev => {
+          const prevMap = Object.fromEntries(prev.map(p => [p.id, p.reply_count ?? 0]));
           const combined = append ? [...prev, ...list] : list;
           const seen = new Set<string>();
-          return combined.filter(p => {
+          const merged = combined.map(p => ({
+            ...p,
+            reply_count: Math.max(p.reply_count ?? 0, prevMap[p.id] ?? 0),
+          }));
+          return merged.filter(p => {
             if (seen.has(p.id)) return false;
             seen.add(p.id);
             return true;
@@ -396,7 +401,9 @@ export default function ProfileScreen() {
         setReplyCounts(prev => {
           const counts = { ...prev };
           list.forEach(p => {
-            counts[p.id] = p.reply_count ?? 0;
+            const current = counts[p.id] ?? 0;
+            const incoming = p.reply_count ?? 0;
+            counts[p.id] = Math.max(current, incoming);
           });
           return counts;
         });


### PR DESCRIPTION
## Summary
- avoid blank screen by showing a loader while auth session initializes
- recover session using async `getSession` and drop direct calls to `supabase.auth.user`
- fix nullish coalescing syntax
- preserve reply counts when posting via quick reply modal

## Testing
- `npm test` *(fails: Missing script)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853d53c4c34832291b855329e6d591a