### PR TITLE
Adjust reply threadline

### DIFF
--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -612,7 +612,10 @@ export default function ReplyDetailScreen() {
           <>
               {originalPost && (
                 <View style={[styles.post, styles.longReply]}>
-                  <View style={styles.threadLine} pointerEvents="none" />
+                  <View
+                    style={[styles.threadLine, styles.threadLineStartMid]}
+                    pointerEvents="none"
+                  />
                   {user?.id === originalPost.user_id && (
                     <TouchableOpacity
                       onPress={() => confirmDeletePost(originalPost.id)}
@@ -993,6 +996,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.accent,
     zIndex: 0,
 
+  },
+  threadLineStartMid: {
+    top: 34,
   },
   threadLineEnd: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- start thread line midway down the original post in reply detail screens

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0af20ac8322805ab3561a9e661e