### PR TITLE
Add cancel button to reply modals

### DIFF
--- a/app/components/ReplyModal.tsx
+++ b/app/components/ReplyModal.tsx
@@ -64,6 +64,13 @@ export default function ReplyModal({ visible, onSubmit, onClose }: ReplyModalPro
     onClose();
   };
 
+  const handleCancel = () => {
+    setText('');
+    setImage(null);
+    setVideo(null);
+    onClose();
+  };
+
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
       <KeyboardAvoidingView
@@ -92,6 +99,7 @@ export default function ReplyModal({ visible, onSubmit, onClose }: ReplyModalPro
             <Button title="Add Image" onPress={pickImage} />
             <Button title="Add Video" onPress={pickVideo} />
             <Button title="Post" onPress={handleSubmit} />
+            <Button title="Cancel" onPress={handleCancel} />
           </View>
         </View>
       </KeyboardAvoidingView>

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -340,6 +340,13 @@ export default function ProfileScreen() {
 
   };
 
+  const handleReplyCancel = () => {
+    setReplyText('');
+    setReplyImage(null);
+    setReplyVideo(null);
+    setReplyModalVisible(false);
+  };
+
 
 
   const pickImage = async () => {
@@ -655,6 +662,7 @@ export default function ProfileScreen() {
               <Button title="Add Image" onPress={pickReplyImage} />
               <Button title="Add Video" onPress={pickReplyVideo} />
               <Button title="Post" onPress={handleReplySubmit} />
+              <Button title="Cancel" onPress={handleReplyCancel} />
             </View>
           </View>
         </KeyboardAvoidingView>


### PR DESCRIPTION
## Summary
- allow closing reply modals without posting

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856a122a2e8832290ad400903074803