### PR TITLE
Adjust video overlay positions

### DIFF
--- a/app/components/VideoFeedItem.tsx
+++ b/app/components/VideoFeedItem.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
   },
   infoContainer: {
     position: 'absolute',
-    bottom: 80,
+    bottom: 140,
     left: 10,
     paddingRight: 80,
   },
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
   },
   muteButton: {
     position: 'absolute',
-    bottom: 20,
+    bottom: 80,
     right: 20,
     backgroundColor: 'rgba(0,0,0,0.5)',
     padding: 10,


### PR DESCRIPTION
## Summary
- keep video controls clear of the bottom tab bar by raising their position

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856ce240d7c8322930371d9cd581ade