### PR TITLE
Adjust video overlay positions

### DIFF
--- a/app/components/VideoFeedItem.tsx
+++ b/app/components/VideoFeedItem.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
   },
   infoContainer: {
     position: 'absolute',
-    bottom: 80,
+    bottom: 140,
     left: 10,
     paddingRight: 80,
   },
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
   },
   muteButton: {
     position: 'absolute',
-    bottom: 20,
+    bottom: 120,
     right: 20,
     backgroundColor: 'rgba(0,0,0,0.5)',
     padding: 10,

--- a/app/screens/VideoScreen.tsx
+++ b/app/screens/VideoScreen.tsx
@@ -30,7 +30,7 @@ export default function VideoScreen() {
   const [videos, setVideos] = useState<FeedVideo[]>([]);
   const [cached, setCached] = useState<CachedMap>({});
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [muted, setMuted] = useState(true);
+  const [muted, setMuted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);


### PR DESCRIPTION
## Summary
- keep video controls clear of the bottom tab bar by raising their position
- allow videos to play with sound by default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856ce240d7c8322930371d9cd581ade