### PR TITLE
Add stories feature with modal viewer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './AuthContext';
 import Navigator from './Navigator';
 import { PostStoreProvider } from './app/contexts/PostStoreContext';
+import { StoryProvider } from './app/contexts/StoryContext';
 
 import { Buffer } from 'buffer';
 import process from 'process';
@@ -14,9 +15,11 @@ export default function App() {
   return (
     <AuthProvider>
       <PostStoreProvider>
-        <NavigationContainer>
-          <Navigator />
-        </NavigationContainer>
+        <StoryProvider>
+          <NavigationContainer>
+            <Navigator />
+          </NavigationContainer>
+        </StoryProvider>
       </PostStoreProvider>
     </AuthProvider>
   );

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql` **and** `sql/marketplace.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql`, `sql/marketplace.sql` **and** `sql/stories.sql` from this repo. This creates the required tables (including nested replies and stories) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
 
 
 
-3. Create public storage buckets named `market-images`, `post-images`, `post-videos` and `reply-videos` in Supabase so listing media can be uploaded. Then run `sql/storage.sql` to allow authenticated users to upload and everyone to view files.
+3. Create public storage buckets named `market-images`, `post-images`, `post-videos`, `reply-videos` and `story-media` in Supabase so listing and story media can be uploaded. Then run `sql/storage.sql` to allow authenticated users to upload and everyone to view files.
 
 
 4. Copy your project's URL and `anon` key into `lib/supabase.js`.

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -4,6 +4,7 @@ import { Video } from 'expo-av';
 import useLike from '../hooks/useLike';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../styles/colors';
+import StoryAvatar from './StoryAvatar';
 
 export interface Post {
   id: string;
@@ -106,17 +107,12 @@ function PostCard({
           </TouchableOpacity>
         )}
         <View style={styles.row}>
-          <TouchableOpacity
-            onPress={e => {
-              e.stopPropagation();
-              onProfilePress();
-            }}
-          >
-            {finalAvatarUri ? (
-              <Image source={{ uri: finalAvatarUri }} style={styles.avatar} />
-            ) : (
-              <View style={[styles.avatar, styles.placeholder]} />
-            )}
+          <TouchableOpacity onPress={e => e.stopPropagation()}>
+            <StoryAvatar
+              userId={post.user_id}
+              uri={finalAvatarUri}
+              onFallbackPress={onProfilePress}
+            />
           </TouchableOpacity>
           <View style={{ flex: 1 }}>
             <View style={styles.headerRow}>

--- a/app/components/StoryAvatar.tsx
+++ b/app/components/StoryAvatar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors } from '../styles/colors';
+import useStoryStatus from '../hooks/useStoryStatus';
+import { useStories } from '../contexts/StoryContext';
+
+interface Props {
+  userId: string;
+  uri?: string;
+  size?: number;
+  onFallbackPress?: () => void;
+}
+
+export default function StoryAvatar({ userId, uri, size = 48, onFallbackPress }: Props) {
+  const hasStory = useStoryStatus(userId);
+  const { openUserStories } = useStories();
+
+  const handlePress = () => {
+    if (hasStory) openUserStories(userId);
+    else onFallbackPress?.();
+  };
+
+  const ringSize = size + 4;
+
+  return (
+    <TouchableOpacity onPress={handlePress}>
+      <View
+        style={hasStory ? [styles.ring, { width: ringSize, height: ringSize, borderRadius: ringSize / 2 }] : null}
+      >
+        {uri ? (
+          <Image source={{ uri }} style={{ width: size, height: size, borderRadius: size / 2 }} />
+        ) : (
+          <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: '#555' }} />
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  ring: {
+    borderWidth: 2,
+    borderColor: colors.storyRing,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/components/StoryModal.tsx
+++ b/app/components/StoryModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Modal, StyleSheet } from 'react-native';
+import Stories from 'react-native-stories-view';
+import { colors } from '../styles/colors';
+import { Story } from '../contexts/StoryContext';
+
+interface Props {
+  visible: boolean;
+  stories: Story[];
+  onClose: () => void;
+}
+
+export default function StoryModal({ visible, stories, onClose }: Props) {
+  if (!visible) return null;
+  const data = stories.map(s => ({ story: s.media_url, swipeText: s.overlay_text || '' }));
+  return (
+    <Modal visible={visible} onRequestClose={onClose} animationType="slide">
+      <Stories
+        stories={data}
+        onComplete={onClose}
+        onClose={onClose}
+        duration={5}
+        customStyles={{ storyContainer: styles.container }}
+      />
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.background,
+  },
+});

--- a/app/components/StoryUploadModal.tsx
+++ b/app/components/StoryUploadModal.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import {
+  View,
+  TextInput,
+  Button,
+  Image,
+  Modal,
+  StyleSheet,
+} from 'react-native';
+import { Video } from 'expo-av';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
+import { useAuth } from '../../AuthContext';
+import { supabase, STORY_BUCKET } from '../../lib/supabase';
+import { colors } from '../styles/colors';
+import { uploadImage } from '../../lib/uploadImage';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function StoryUploadModal({ visible, onClose }: Props) {
+  const { user } = useAuth()!;
+  const [text, setText] = useState('');
+  const [media, setMedia] = useState<string | null>(null);
+  const [isVideo, setIsVideo] = useState(false);
+
+  const pickImage = async () => {
+    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images });
+    if (!res.canceled) {
+      const uri = res.assets[0].uri;
+      const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
+      setMedia(`data:image/jpeg;base64,${base64}`);
+      setIsVideo(false);
+    }
+  };
+
+  const pickVideo = async () => {
+    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Videos });
+    if (!res.canceled) {
+      setMedia(res.assets[0].uri);
+      setIsVideo(true);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!user || !media) { onClose(); return; }
+    let url: string | null = null;
+    if (isVideo) {
+      try {
+        const ext = media.split('.').pop() || 'mp4';
+        const path = `${user.id}-${Date.now()}.${ext}`;
+        const resp = await fetch(media);
+        const blob = await resp.blob();
+        const { error } = await supabase.storage.from(STORY_BUCKET).upload(path, blob);
+        if (!error) {
+          url = supabase.storage.from(STORY_BUCKET).getPublicUrl(path).publicURL;
+        }
+      } catch (e) {
+        console.error('video upload failed', e);
+      }
+    } else {
+      url = await uploadImage(media, user.id);
+    }
+    if (url) {
+      await supabase.from('stories').insert({ user_id: user.id, media_url: url, overlay_text: text });
+    }
+    setText('');
+    setMedia(null);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.container}>
+        <TextInput
+          placeholder="Say something"
+          placeholderTextColor={colors.muted}
+          value={text}
+          onChangeText={setText}
+          style={styles.input}
+        />
+        {media && !isVideo && <Image source={{ uri: media }} style={styles.preview} />}
+        {media && isVideo && <Video source={{ uri: media }} style={styles.preview} useNativeControls isMuted resizeMode="contain" />}
+        <View style={styles.row}>
+          <Button title="Pick Image" onPress={pickImage} />
+          <Button title="Pick Video" onPress={pickVideo} />
+          <Button title="Post" onPress={handleSubmit} />
+          <Button title="Cancel" onPress={onClose} />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { backgroundColor: colors.background, flex: 1, padding: 20, justifyContent: 'center' },
+  input: { backgroundColor: '#333', color: colors.text, padding: 10, borderRadius: 6, marginBottom: 10 },
+  preview: { width: '100%', height: 200, borderRadius: 6, marginBottom: 10 },
+  row: { flexDirection: 'row', justifyContent: 'space-between' },
+});

--- a/app/contexts/StoryContext.tsx
+++ b/app/contexts/StoryContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState } from 'react';
+import { supabase } from '../../lib/supabase';
+import StoryModal from '../components/StoryModal';
+
+export interface Story {
+  id: string;
+  user_id: string;
+  media_url: string;
+  overlay_text?: string | null;
+  created_at: string;
+}
+
+interface StoryContextValue {
+  openUserStories: (userId: string) => Promise<void>;
+}
+
+const StoryContext = createContext<StoryContextValue | undefined>(undefined);
+
+export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [visible, setVisible] = useState(false);
+  const [stories, setStories] = useState<Story[]>([]);
+  const openUserStories = async (userId: string) => {
+    if (visible) return;
+    const since = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const { data } = await supabase
+      .from('stories')
+      .select('*')
+      .eq('user_id', userId)
+      .gt('created_at', since)
+      .order('created_at', { ascending: true });
+    if (!data || data.length === 0) return;
+    setStories(data as Story[]);
+    setVisible(true);
+  };
+  const handleClose = () => setVisible(false);
+  return (
+    <StoryContext.Provider value={{ openUserStories }}>
+      {children}
+      <StoryModal visible={visible} stories={stories} onClose={handleClose} />
+    </StoryContext.Provider>
+  );
+};
+
+export function useStories() {
+  const ctx = useContext(StoryContext);
+  if (!ctx) throw new Error('StoryContext missing');
+  return ctx;
+}

--- a/app/hooks/useStoryStatus.ts
+++ b/app/hooks/useStoryStatus.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabase';
+
+export default function useStoryStatus(userId: string) {
+  const [hasStory, setHasStory] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchStatus = async () => {
+      const since = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const { data } = await supabase
+        .from('stories')
+        .select('id')
+        .eq('user_id', userId)
+        .gt('created_at', since)
+        .limit(1);
+      if (mounted) setHasStory((data?.length ?? 0) > 0);
+    };
+    fetchStatus();
+    return () => {
+      mounted = false;
+    };
+  }, [userId]);
+
+  return hasStory;
+}

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../lib/supabase';
 import { uploadImage } from '../../lib/uploadImage';
 import ReplyModal from '../components/ReplyModal';
+import StoryUploadModal from '../components/StoryUploadModal';
 
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -79,6 +80,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
   const [searchVisible, setSearchVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchItem[]>([]);
+  const [storyVisible, setStoryVisible] = useState(false);
 
 
   if (!user || !profile) {
@@ -465,6 +467,12 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
           ref={listRef}
 
           data={posts}
+          ListHeaderComponent={() => (
+            <View style={styles.storiesPlaceholder}>
+              <Text style={styles.storiesPlaceholderText}>Stories coming soon...</Text>
+              <Button title="Add Story" onPress={() => setStoryVisible(true)} />
+            </View>
+          )}
           keyExtractor={item => item.id}
           style={{ flex: 1 }}
           contentContainerStyle={{ paddingBottom: 20 }}
@@ -511,6 +519,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
         onSubmit={handleReplySubmit}
         onClose={() => setReplyModalVisible(false)}
       />
+      <StoryUploadModal visible={storyVisible} onClose={() => setStoryVisible(false)} />
 
       <Modal visible={searchVisible} animationType="slide" onRequestClose={closeSearch}>
         <View style={styles.searchContainer}>
@@ -623,6 +632,14 @@ const styles = StyleSheet.create({
     marginTop: 10,
 
   },
+  storiesPlaceholder: {
+    height: 80,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderBottomColor: '#444',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  storiesPlaceholderText: { color: colors.muted },
   noResultsWrapper: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   noResultsText: { color: colors.text, marginTop: 20 },
 });

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -29,6 +29,7 @@ import useLike from '../hooks/useLike';
 import { postEvents } from '../postEvents';
 import { CONFIRM_ACTION } from '../constants/ui';
 import ReplyModal from '../components/ReplyModal';
+import StoryAvatar from '../components/StoryAvatar';
 
 
 const CHILD_PREFIX = 'cached_child_replies_';
@@ -630,21 +631,15 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
                 )}
                 <View style={styles.row}>
-                  <TouchableOpacity
-                  onPress={() =>
-                    user?.id === originalPost.user_id
-                      ? navigation.navigate('Profile')
-                      : navigation.navigate('OtherUserProfile', {
-                          userId: originalPost.user_id,
-                        })
-                  }
-                  >
-                    {user?.id === originalPost.user_id && profileImageUri ? (
-                      <Image source={{ uri: profileImageUri }} style={styles.avatar} />
-                    ) : (
-                      <View style={[styles.avatar, styles.placeholder]} />
-                    )}
-                  </TouchableOpacity>
+                  <StoryAvatar
+                    userId={originalPost.user_id}
+                    uri={user?.id === originalPost.user_id ? profileImageUri ?? undefined : originalPost.profiles?.image_url ?? undefined}
+                    onFallbackPress={() =>
+                      user?.id === originalPost.user_id
+                        ? navigation.navigate('Profile')
+                        : navigation.navigate('OtherUserProfile', { userId: originalPost.user_id })
+                    }
+                  />
 
                   <View style={{ flex: 1 }}>
                     <View style={styles.headerRow}>
@@ -708,21 +703,15 @@ export default function ReplyDetailScreen() {
                     </TouchableOpacity>
                   )}
                   <View style={styles.row}>
-                    <TouchableOpacity
-                      onPress={() =>
+                    <StoryAvatar
+                      userId={a.user_id}
+                      uri={avatarUri ?? undefined}
+                      onFallbackPress={() =>
                         isMe
                           ? navigation.navigate('Profile')
-                          : navigation.navigate('OtherUserProfile', {
-                              userId: a.user_id,
-                            })
+                          : navigation.navigate('OtherUserProfile', { userId: a.user_id })
                       }
-                    >
-                      {avatarUri ? (
-                        <Image source={{ uri: avatarUri }} style={styles.avatar} />
-                      ) : (
-                        <View style={[styles.avatar, styles.placeholder]} />
-                      )}
-                    </TouchableOpacity>
+                    />
 
                     <View style={{ flex: 1 }}>
                     <View style={styles.headerRow}>
@@ -779,21 +768,15 @@ export default function ReplyDetailScreen() {
                 </TouchableOpacity>
               )}
               <View style={styles.row}>
-                <TouchableOpacity
-                  onPress={() =>
+                <StoryAvatar
+                  userId={parent.user_id}
+                  uri={user?.id === parent.user_id ? profileImageUri ?? undefined : parent.profiles?.image_url ?? undefined}
+                  onFallbackPress={() =>
                     user?.id === parent.user_id
                       ? navigation.navigate('Profile')
-                      : navigation.navigate('OtherUserProfile', {
-                          userId: parent.user_id,
-                        })
+                      : navigation.navigate('OtherUserProfile', { userId: parent.user_id })
                   }
-                >
-                  {user?.id === parent.user_id && profileImageUri ? (
-                    <Image source={{ uri: profileImageUri }} style={styles.avatar} />
-                  ) : (
-                    <View style={[styles.avatar, styles.placeholder]} />
-                  )}
-                </TouchableOpacity>
+                />
 
                 <View style={{ flex: 1 }}>
                   <View style={styles.headerRow}>
@@ -871,21 +854,15 @@ export default function ReplyDetailScreen() {
                   </TouchableOpacity>
                 )}
                 <View style={styles.row}>
-                  <TouchableOpacity
-                    onPress={() =>
+                  <StoryAvatar
+                    userId={item.user_id}
+                    uri={avatarUri ?? undefined}
+                    onFallbackPress={() =>
                       isMe
                         ? navigation.navigate('Profile')
-                        : navigation.navigate('OtherUserProfile', {
-                            userId: item.user_id,
-                          })
+                        : navigation.navigate('OtherUserProfile', { userId: item.user_id })
                     }
-                  >
-                    {avatarUri ? (
-                      <Image source={{ uri: avatarUri }} style={styles.avatar} />
-                    ) : (
-                      <View style={[styles.avatar, styles.placeholder]} />
-                    )}
-                  </TouchableOpacity>
+                  />
 
                   <View style={{ flex: 1 }}>
                     <View style={styles.headerRow}>

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -2,6 +2,7 @@ export const colors = {
   background: '#2c2c54',
   text: '#f0f0f0',
   accent: '#0070f3',
+  storyRing: '#0a84ff',
   muted: '#cccccc',
 };
 

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -16,5 +16,6 @@ export const MARKET_BUCKET = 'market-images';
 export const POST_BUCKET = 'post-images';
 export const POST_VIDEO_BUCKET = 'post-videos';
 export const REPLY_VIDEO_BUCKET = 'reply-videos';
+export const STORY_BUCKET = 'story-media';
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-native-screens": "~4.10.0",
         "react-native-tab-view": "^4.0.12",
         "react-native-video": "^6.1.0",
+        "react-native-stories-view": "^1.1.0",
         "stream-browserify": "^3.0.0",
         "util": "^0.12.5"
       },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-screens": "~4.10.0",
     "react-native-tab-view": "^4.0.12",
     "react-native-video": "^6.1.0",
+    "react-native-stories-view": "^1.1.0",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "expo-file-system": "~18.1.10",

--- a/sql/storage.sql
+++ b/sql/storage.sql
@@ -58,3 +58,16 @@ create policy "Reply video uploads" on storage.objects
 create policy "Public reply video access" on storage.objects
   for select using (bucket_id = 'reply-videos');
 
+-- Policies for the story-media storage bucket
+insert into storage.buckets (id, name, public)
+  values ('story-media', 'story-media', true)
+  on conflict (id) do update set public = true;
+
+create policy "Story media uploads" on storage.objects
+  for insert with check (
+    bucket_id = 'story-media' and auth.role() = 'authenticated'
+  );
+
+create policy "Public story media access" on storage.objects
+  for select using (bucket_id = 'story-media');
+

--- a/sql/stories.sql
+++ b/sql/stories.sql
@@ -1,0 +1,20 @@
+-- Stories table for ephemeral user stories
+create extension if not exists "uuid-ossp";
+create table if not exists public.stories (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  media_url text not null,
+  overlay_text text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.stories enable row level security;
+
+create policy "Users can insert stories" on public.stories
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users can delete their stories" on public.stories
+  for delete using (auth.uid() = user_id);
+
+create policy "Anyone can read stories" on public.stories
+  for select using (true);


### PR DESCRIPTION
## Summary
- install `react-native-stories-view`
- support story ring color
- create Story context, modal and avatar component
- add story upload modal and placeholder in home feed
- show story rings around avatars and open stories
- add Supabase table and storage policies for stories

## Testing
- `npm -s run test` *(fails: no tests defined)*
- `npm -s run build` *(fails: no build script defined)*


------
https://chatgpt.com/codex/tasks/task_e_6856de83d77883229061444fb0c6bb9a