### PR TITLE
Fix like toggle re-render issue

### DIFF
--- a/app/contexts/PostStoreContext.tsx
+++ b/app/contexts/PostStoreContext.tsx
@@ -28,7 +28,10 @@ interface ItemInfo {
 }
 
 interface PostStore {
-  posts: Record<string, PostState>;
+  /**
+   * Retrieve the like state for a post without triggering a re-render
+   */
+  getState: (id: string) => PostState | undefined;
   initialize: (items: ItemInfo[]) => Promise<void>;
   mergeLiked: (map: Record<string, boolean>) => Promise<void>;
   toggleLike: (id: string, isReply?: boolean) => Promise<void>;
@@ -43,6 +46,7 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   const { user, updatePost } = useAuth()!;
   const [posts, setPosts] = useState<Record<string, PostState>>({});
   const postsRef = useRef<Record<string, PostState>>({});
+  const getState = useCallback((id: string) => postsRef.current[id], []);
   const lastLoadedUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -67,7 +71,11 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
           try {
             const arr = JSON.parse(postStored);
             arr.forEach((p: any) => {
-              if (p.id && typeof p.like_count === 'number' && likeMap[p.id] === undefined) {
+              if (
+                p.id &&
+                typeof p.like_count === 'number' &&
+                likeMap[p.id] === undefined
+              ) {
                 likeMap[p.id] = p.like_count;
               }
             });
@@ -82,13 +90,13 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
           );
           likedMap = likedStored ? JSON.parse(likedStored) : {};
         }
-        setPosts(prev => {
+        setPosts((prev) => {
           const merged = { ...prev };
           const ids = new Set([
             ...Object.keys(likeMap),
             ...Object.keys(likedMap),
           ]);
-          ids.forEach(id => {
+          ids.forEach((id) => {
             merged[id] = {
               likeCount: prev[id]?.likeCount ?? likeMap[id] ?? 0,
               liked: prev[id]?.liked ?? !!likedMap[id],
@@ -109,14 +117,14 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [user?.id]);
 
   const initialize = useCallback(async (items: ItemInfo[]) => {
-    setPosts(prev => {
+    setPosts((prev) => {
       const updated = { ...prev };
-      items.forEach(item => {
+      items.forEach((item) => {
         const existing = updated[item.id];
         const likeCount =
           item.like_count !== undefined && item.like_count !== null
             ? item.like_count
-            : existing?.likeCount ?? 0;
+            : (existing?.likeCount ?? 0);
 
         const liked = existing?.liked ?? false;
         updated[item.id] = { likeCount, liked };
@@ -126,7 +134,7 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
     try {
       const stored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
       const map = stored ? JSON.parse(stored) : {};
-      items.forEach(i => {
+      items.forEach((i) => {
         if (i.like_count !== undefined && i.like_count !== null) {
           map[i.id] = i.like_count;
         }
@@ -137,121 +145,144 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, []);
 
-  const mergeLiked = useCallback(async (likedMap: Record<string, boolean>) => {
-    if (!user) return;
-    setPosts(prev => {
-      const updated = { ...prev };
-      Object.entries(likedMap).forEach(([id, liked]) => {
-        const existing = updated[id] || { likeCount: 0, liked: false };
-        updated[id] = { likeCount: existing.likeCount, liked };
+  const mergeLiked = useCallback(
+    async (likedMap: Record<string, boolean>) => {
+      if (!user) return;
+      setPosts((prev) => {
+        const updated = { ...prev };
+        Object.entries(likedMap).forEach(([id, liked]) => {
+          const existing = updated[id] || { likeCount: 0, liked: false };
+          updated[id] = { likeCount: existing.likeCount, liked };
+        });
+        return updated;
       });
-      return updated;
-    });
-    try {
-      const stored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
-      const map = stored ? JSON.parse(stored) : {};
-      Object.entries(likedMap).forEach(([id, liked]) => {
-        if (liked) {
-          map[id] = true;
-        } else {
-          delete map[id];
-        }
-      });
-      await AsyncStorage.setItem(
-        `${LIKED_KEY_PREFIX}${user.id}`,
-        JSON.stringify(map),
-      );
-    } catch (e) {
-      console.error('Failed to persist liked state', e);
-    }
-  }, [user?.id]);
-
-
-  const toggleLike = useCallback(async (id: string, isReply: boolean = false) => {
-    if (!user) return;
-    const current = postsRef.current[id] || { likeCount: 0, liked: false };
-    const newLiked = !current.liked;
-    let newCount = current.likeCount + (newLiked ? 1 : -1);
-    setPosts(prev => ({ ...prev, [id]: { likeCount: newCount, liked: newLiked } }));
-    if (!isReply) {
-      likeEvents.emit('likeChanged', { id, count: newCount, liked: newLiked });
-      updatePost(id, { like_count: newCount, liked: newLiked });
-    }
-
-    try {
-      const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
-      const likeMap = likeStored ? JSON.parse(likeStored) : {};
-      likeMap[id] = newCount;
-      await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-
-      const likedStored = await AsyncStorage.getItem(`${LIKED_KEY_PREFIX}${user.id}`);
-      const likedMap = likedStored ? JSON.parse(likedStored) : {};
-      if (newLiked) {
-        likedMap[id] = true;
-      } else {
-        delete likedMap[id];
-      }
-      await AsyncStorage.setItem(
-        `${LIKED_KEY_PREFIX}${user.id}`,
-        JSON.stringify(likedMap),
-      );
-
-      if (!isReply) {
-        try {
-          const postStored = await AsyncStorage.getItem('cached_posts');
-          if (postStored) {
-            const arr = JSON.parse(postStored);
-            const updated = arr.map((p: any) =>
-              p.id === id ? { ...p, like_count: newCount } : p,
-            );
-            await AsyncStorage.setItem('cached_posts', JSON.stringify(updated));
+      try {
+        const stored = await AsyncStorage.getItem(
+          `${LIKED_KEY_PREFIX}${user.id}`,
+        );
+        const map = stored ? JSON.parse(stored) : {};
+        Object.entries(likedMap).forEach(([id, liked]) => {
+          if (liked) {
+            map[id] = true;
+          } else {
+            delete map[id];
           }
-        } catch (err) {
-          console.error('Failed to update cached posts', err);
-        }
+        });
+        await AsyncStorage.setItem(
+          `${LIKED_KEY_PREFIX}${user.id}`,
+          JSON.stringify(map),
+        );
+      } catch (e) {
+        console.error('Failed to persist liked state', e);
+      }
+    },
+    [user?.id],
+  );
+
+  const toggleLike = useCallback(
+    async (id: string, isReply: boolean = false) => {
+      if (!user) return;
+      const current = postsRef.current[id] || { likeCount: 0, liked: false };
+      const newLiked = !current.liked;
+      let newCount = current.likeCount + (newLiked ? 1 : -1);
+      setPosts((prev) => ({
+        ...prev,
+        [id]: { likeCount: newCount, liked: newLiked },
+      }));
+      if (!isReply) {
+        likeEvents.emit('likeChanged', {
+          id,
+          count: newCount,
+          liked: newLiked,
+        });
+        updatePost(id, { like_count: newCount, liked: newLiked });
       }
 
-      if (id.startsWith('temp-')) {
-        // Don't sync with Supabase until the item has a real UUID
-        return;
-      }
-
-
-      if (newLiked) {
-        await supabase
-          .from('likes')
-          .insert({ user_id: user.id, [isReply ? 'reply_id' : 'post_id']: id });
-      } else {
-        await supabase
-          .from('likes')
-          .delete()
-          .match({ user_id: user.id, [isReply ? 'reply_id' : 'post_id']: id });
-      }
-      const { count } = await supabase
-        .from('likes')
-        .select('id', { count: 'exact', head: true })
-        .match(isReply ? { reply_id: id } : { post_id: id });
-      if (typeof count === 'number') {
-        newCount = count;
-        setPosts(prev => ({
-          ...prev,
-          [id]: { likeCount: count, liked: newLiked },
-        }));
-        likeMap[id] = count;
+      try {
+        const likeStored = await AsyncStorage.getItem(LIKE_COUNT_KEY);
+        const likeMap = likeStored ? JSON.parse(likeStored) : {};
+        likeMap[id] = newCount;
         await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
-        if (!isReply) {
-          likeEvents.emit('likeChanged', { id, count, liked: newLiked });
-          updatePost(id, { like_count: count, liked: newLiked });
-        }
-      }
-    } catch (e) {
-      console.error('Failed to toggle like', e);
-    }
-  }, [user?.id, updatePost]);
 
+        const likedStored = await AsyncStorage.getItem(
+          `${LIKED_KEY_PREFIX}${user.id}`,
+        );
+        const likedMap = likedStored ? JSON.parse(likedStored) : {};
+        if (newLiked) {
+          likedMap[id] = true;
+        } else {
+          delete likedMap[id];
+        }
+        await AsyncStorage.setItem(
+          `${LIKED_KEY_PREFIX}${user.id}`,
+          JSON.stringify(likedMap),
+        );
+
+        if (!isReply) {
+          try {
+            const postStored = await AsyncStorage.getItem('cached_posts');
+            if (postStored) {
+              const arr = JSON.parse(postStored);
+              const updated = arr.map((p: any) =>
+                p.id === id ? { ...p, like_count: newCount } : p,
+              );
+              await AsyncStorage.setItem(
+                'cached_posts',
+                JSON.stringify(updated),
+              );
+            }
+          } catch (err) {
+            console.error('Failed to update cached posts', err);
+          }
+        }
+
+        if (id.startsWith('temp-')) {
+          // Don't sync with Supabase until the item has a real UUID
+          return;
+        }
+
+        if (newLiked) {
+          await supabase
+            .from('likes')
+            .insert({
+              user_id: user.id,
+              [isReply ? 'reply_id' : 'post_id']: id,
+            });
+        } else {
+          await supabase
+            .from('likes')
+            .delete()
+            .match({
+              user_id: user.id,
+              [isReply ? 'reply_id' : 'post_id']: id,
+            });
+        }
+        const { count } = await supabase
+          .from('likes')
+          .select('id', { count: 'exact', head: true })
+          .match(isReply ? { reply_id: id } : { post_id: id });
+        if (typeof count === 'number') {
+          newCount = count;
+          setPosts((prev) => ({
+            ...prev,
+            [id]: { likeCount: count, liked: newLiked },
+          }));
+          likeMap[id] = count;
+          await AsyncStorage.setItem(LIKE_COUNT_KEY, JSON.stringify(likeMap));
+          if (!isReply) {
+            likeEvents.emit('likeChanged', { id, count, liked: newLiked });
+            updatePost(id, { like_count: count, liked: newLiked });
+          }
+        }
+      } catch (e) {
+        console.error('Failed to toggle like', e);
+      }
+    },
+    [user?.id, updatePost],
+  );
 
   const remove = useCallback((id: string) => {
-    setPosts(prev => {
+    setPosts((prev) => {
       const { [id]: _omit, ...rest } = prev;
       return rest;
     });
@@ -259,8 +290,8 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const value = useMemo(
-    () => ({ posts, initialize, mergeLiked, toggleLike, remove }),
-    [posts, initialize, mergeLiked, toggleLike, remove],
+    () => ({ getState, initialize, mergeLiked, toggleLike, remove }),
+    [getState, initialize, mergeLiked, toggleLike, remove],
   );
 
   return (
@@ -272,6 +303,7 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
 
 export function usePostStore() {
   const ctx = useContext(PostStoreContext);
-  if (!ctx) throw new Error('usePostStore must be used within PostStoreProvider');
+  if (!ctx)
+    throw new Error('usePostStore must be used within PostStoreProvider');
   return ctx;
 }


### PR DESCRIPTION
## Summary
- update PostStore context to expose `getState` instead of full posts map
- adjust ProfileScreen to use `getState`
- rewrite `useLike` hook to store local state and subscribe to `likeEvents`

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68579dbaa6488322b2614108d3977918