### PR TITLE
Fix feed reload on like

### DIFF
--- a/app/contexts/PostStoreContext.tsx
+++ b/app/contexts/PostStoreContext.tsx
@@ -203,7 +203,9 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
           count: newCount,
           liked: newLiked,
         });
-        updatePost(id, { like_count: newCount, liked: newLiked });
+        // updatePost would cause a global context change which re-renders the
+        // entire HomeScreen feed. The like event is sufficient for local UI
+        // updates, so avoid calling updatePost here.
       }
 
       try {


### PR DESCRIPTION
## Summary
- stop calling `updatePost` when toggling likes so the HomeScreen feed does not refresh

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857b01195b88322af9a70cbe814e84b