### PR TITLE
Fix feed refresh on like toggles

### DIFF
--- a/app/screens/FollowingFeedScreen.jsx
+++ b/app/screens/FollowingFeedScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import PostCard from '../components/PostCard';
 
 const PostItem = React.memo(function PostItem({
@@ -113,24 +113,28 @@ export default function FollowingFeedScreen() {
   }, [user?.id, initialize]);
 
 
-  useEffect(() => {
-    const onLikeChanged = ({ id, count }) => {
-      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
-    };
-    const onPostDeleted = postId => {
-      setPosts(prev => prev.filter(p => p.id !== postId));
-      setReplyCounts(prev => {
-        const { [postId]: _omit, ...rest } = prev;
-        return rest;
-      });
-    };
-    likeEvents.on('likeChanged', onLikeChanged);
-    postEvents.on('postDeleted', onPostDeleted);
-    return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
-      postEvents.off('postDeleted', onPostDeleted);
-    };
-  }, []);
+  useFocusEffect(
+    React.useCallback(() => {
+      const onLikeChanged = ({ id, count }) => {
+        setPosts(prev =>
+          prev.map(p => (p.id === id ? { ...p, like_count: count } : p)),
+        );
+      };
+      const onPostDeleted = postId => {
+        setPosts(prev => prev.filter(p => p.id !== postId));
+        setReplyCounts(prev => {
+          const { [postId]: _omit, ...rest } = prev;
+          return rest;
+        });
+      };
+      likeEvents.on('likeChanged', onLikeChanged);
+      postEvents.on('postDeleted', onPostDeleted);
+      return () => {
+        likeEvents.off('likeChanged', onLikeChanged);
+        postEvents.off('postDeleted', onPostDeleted);
+      };
+    }, []),
+  );
 
   useEffect(() => {
     fetchPosts(0);

--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, Image, ActivityIndicator, FlatList, Button, TouchableOpacity } from 'react-native';
-import { useRoute, useNavigation } from '@react-navigation/native';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
 import FollowButton from '../components/FollowButton';
@@ -81,20 +81,24 @@ export default function OtherUserProfileScreen() {
     loadPosts();
   }, [idToLoad, initialize]);
 
-  useEffect(() => {
-    const onLikeChanged = ({ id, count }) => {
-      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
-    };
-    likeEvents.on('likeChanged', onLikeChanged);
-    const onPostDeleted = postId => {
-      setPosts(prev => prev.filter(p => p.id !== postId));
-    };
-    postEvents.on('postDeleted', onPostDeleted);
-    return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
-      postEvents.off('postDeleted', onPostDeleted);
-    };
-  }, []);
+  useFocusEffect(
+    React.useCallback(() => {
+      const onLikeChanged = ({ id, count }) => {
+        setPosts(prev =>
+          prev.map(p => (p.id === id ? { ...p, like_count: count } : p)),
+        );
+      };
+      likeEvents.on('likeChanged', onLikeChanged);
+      const onPostDeleted = postId => {
+        setPosts(prev => prev.filter(p => p.id !== postId));
+      };
+      postEvents.on('postDeleted', onPostDeleted);
+      return () => {
+        likeEvents.off('likeChanged', onLikeChanged);
+        postEvents.off('postDeleted', onPostDeleted);
+      };
+    }, []),
+  );
 
   if (loading) {
     return (

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -19,7 +19,7 @@ import {
 import { Video } from 'expo-av';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useAuth } from '../../AuthContext';
@@ -155,23 +155,25 @@ export default function ProfileScreen() {
     };
   }, []);
 
-  useEffect(() => {
-    const onLikeChanged = ({
-      id,
-      count,
-      liked,
-    }: {
-      id: string;
-      count: number;
-      liked: boolean;
-    }) => {
-      updatePost(id, { like_count: count, liked });
-    };
-    likeEvents.on('likeChanged', onLikeChanged);
-    return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
-    };
-  }, [updatePost]);
+  useFocusEffect(
+    useCallback(() => {
+      const onLikeChanged = ({
+        id,
+        count,
+        liked,
+      }: {
+        id: string;
+        count: number;
+        liked: boolean;
+      }) => {
+        updatePost(id, { like_count: count, liked });
+      };
+      likeEvents.on('likeChanged', onLikeChanged);
+      return () => {
+        likeEvents.off('likeChanged', onLikeChanged);
+      };
+    }, [updatePost]),
+  );
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -10,7 +10,7 @@ import {
   FlatList,
   TouchableOpacity,
 } from 'react-native';
-import { useRoute, useNavigation } from '@react-navigation/native';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { colors } from '../styles/colors';
 import { useFollowCounts } from '../hooks/useFollowCounts';
@@ -144,15 +144,19 @@ export default function UserProfileScreen() {
     loadPosts();
   }, [userId, initialize]);
 
-  useEffect(() => {
-    const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
-      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
-    };
-    likeEvents.on('likeChanged', onLikeChanged);
-    return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
-    };
-  }, []);
+  useFocusEffect(
+    React.useCallback(() => {
+      const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
+        setPosts(prev =>
+          prev.map(p => (p.id === id ? { ...p, like_count: count } : p)),
+        );
+      };
+      likeEvents.on('likeChanged', onLikeChanged);
+      return () => {
+        likeEvents.off('likeChanged', onLikeChanged);
+      };
+    }, []),
+  );
 
   useEffect(() => {
     const onPostDeleted = (postId: string) => {


### PR DESCRIPTION
## Summary
- update ProfileScreen to only listen to like events while focused
- update FollowingFeedScreen, OtherUserProfileScreen, and UserProfileScreen in the same way

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6d7c0ac8322ab509a9d2bd32311