### PR TITLE
Fix like toggle refresh

### DIFF
--- a/app/screens/FollowingFeedScreen.jsx
+++ b/app/screens/FollowingFeedScreen.jsx
@@ -114,9 +114,6 @@ export default function FollowingFeedScreen() {
 
 
   useEffect(() => {
-    const onLikeChanged = ({ id, count }) => {
-      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
-    };
     const onPostDeleted = postId => {
       setPosts(prev => prev.filter(p => p.id !== postId));
       setReplyCounts(prev => {
@@ -124,10 +121,8 @@ export default function FollowingFeedScreen() {
         return rest;
       });
     };
-    likeEvents.on('likeChanged', onLikeChanged);
     postEvents.on('postDeleted', onPostDeleted);
     return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
       postEvents.off('postDeleted', onPostDeleted);
     };
   }, []);

--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -82,16 +82,11 @@ export default function OtherUserProfileScreen() {
   }, [idToLoad, initialize]);
 
   useEffect(() => {
-    const onLikeChanged = ({ id, count }) => {
-      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
-    };
-    likeEvents.on('likeChanged', onLikeChanged);
     const onPostDeleted = postId => {
       setPosts(prev => prev.filter(p => p.id !== postId));
     };
     postEvents.on('postDeleted', onPostDeleted);
     return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
       postEvents.off('postDeleted', onPostDeleted);
     };
   }, []);

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -144,15 +144,6 @@ export default function UserProfileScreen() {
     loadPosts();
   }, [userId, initialize]);
 
-  useEffect(() => {
-    const onLikeChanged = ({ id, count }: { id: string; count: number }) => {
-      setPosts(prev => prev.map(p => (p.id === id ? { ...p, like_count: count } : p)));
-    };
-    likeEvents.on('likeChanged', onLikeChanged);
-    return () => {
-      likeEvents.off('likeChanged', onLikeChanged);
-    };
-  }, []);
 
   useEffect(() => {
     const onPostDeleted = (postId: string) => {


### PR DESCRIPTION
## Summary
- stop updating feed lists on `likeChanged` events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857bb35b43c8322a4a74a143a8b02f5