### PR TITLE
Fix home feed flicker when liking posts

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -52,6 +52,9 @@ export interface PostCardProps {
   onProfilePress: () => void;
   onDelete: () => void;
   onOpenReplies: () => void;
+  /** Optional callback when the like button is pressed. The delta
+   * will be +1 when liking and -1 when unliking. */
+  onLike?: (delta: number) => void;
   showThreadLine?: boolean;
   /**
    * If true, the thread line should end behind this avatar
@@ -72,6 +75,7 @@ function PostCard({
   onProfilePress,
   onDelete,
   onOpenReplies,
+  onLike,
   showThreadLine = false,
   isLastInThread = false,
 }: PostCardProps) {
@@ -79,6 +83,11 @@ function PostCard({
   const userName = post.profiles?.username || post.username;
   const isReply = (post as any).post_id !== undefined;
   const { likeCount, liked, toggleLike } = useLike(post.id, isReply);
+
+  const handleLikePress = React.useCallback(() => {
+    onLike?.(liked ? -1 : 1);
+    toggleLike();
+  }, [onLike, liked, toggleLike]);
 
   const finalAvatarUri =
     avatarUri ?? post.profiles?.image_url ?? undefined;
@@ -163,7 +172,7 @@ function PostCard({
           style={styles.likeContainer}
           onPress={e => {
             e.stopPropagation();
-            toggleLike();
+            handleLikePress();
           }}
         >
           <Ionicons name={liked ? 'heart' : 'heart-outline'} size={18} color="red" style={{ marginRight: 2 }} />


### PR DESCRIPTION
## Summary
- update `PostCard` to expose an optional `onLike` callback
- optimistically update like count without re-fetching

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1cd54248322bd9c0e6cae154897