### PR TITLE
Fix home feed flicker when liking posts

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -52,6 +52,13 @@ export interface PostCardProps {
   onProfilePress: () => void;
   onDelete: () => void;
   onOpenReplies: () => void;
+  /** Optional callback when the like button is pressed. The delta
+   * will be +1 when liking and -1 when unliking. */
+  onLike?: (delta: number) => void;
+  /** Explicit like count. If omitted, value from useLike will be used */
+  likeCount?: number;
+  /** Explicit liked state. If omitted, value from useLike will be used */
+  liked?: boolean;
   showThreadLine?: boolean;
   /**
    * If true, the thread line should end behind this avatar
@@ -72,13 +79,24 @@ function PostCard({
   onProfilePress,
   onDelete,
   onOpenReplies,
+  onLike,
+  likeCount: likeCountProp,
+  liked: likedProp,
   showThreadLine = false,
   isLastInThread = false,
 }: PostCardProps) {
   const displayName = post.profiles?.name || post.profiles?.username || post.username;
   const userName = post.profiles?.username || post.username;
   const isReply = (post as any).post_id !== undefined;
-  const { likeCount, liked, toggleLike } = useLike(post.id, isReply);
+  const store = useLike(post.id, isReply);
+  const likeCount = likeCountProp ?? store.likeCount;
+  const liked = likedProp ?? store.liked;
+  const toggleLike = store.toggleLike;
+
+  const handleLikePress = React.useCallback(() => {
+    onLike?.(liked ? -1 : 1);
+    toggleLike();
+  }, [onLike, liked, toggleLike]);
 
   const finalAvatarUri =
     avatarUri ?? post.profiles?.image_url ?? undefined;
@@ -163,7 +181,7 @@ function PostCard({
           style={styles.likeContainer}
           onPress={e => {
             e.stopPropagation();
-            toggleLike();
+            handleLikePress();
           }}
         >
           <Ionicons name={liked ? 'heart' : 'heart-outline'} size={18} color="red" style={{ marginRight: 2 }} />

--- a/app/contexts/PostStoreContext.tsx
+++ b/app/contexts/PostStoreContext.tsx
@@ -28,7 +28,8 @@ interface ItemInfo {
 }
 
 interface PostStore {
-  posts: Record<string, PostState>;
+  /** Get the current like state for a given post id */
+  getState: (id: string) => PostState | undefined;
   initialize: (items: ItemInfo[]) => Promise<void>;
   mergeLiked: (map: Record<string, boolean>) => Promise<void>;
   toggleLike: (id: string, isReply?: boolean) => Promise<void>;
@@ -44,6 +45,11 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   const [posts, setPosts] = useState<Record<string, PostState>>({});
   const postsRef = useRef<Record<string, PostState>>({});
   const lastLoadedUserIdRef = useRef<string | null>(null);
+
+  const getState = useCallback(
+    (id: string): PostState | undefined => postsRef.current[id],
+    [],
+  );
 
   useEffect(() => {
     postsRef.current = posts;
@@ -259,8 +265,8 @@ export const PostStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const value = useMemo(
-    () => ({ posts, initialize, mergeLiked, toggleLike, remove }),
-    [posts, initialize, mergeLiked, toggleLike, remove],
+    () => ({ getState, initialize, mergeLiked, toggleLike, remove }),
+    [getState, initialize, mergeLiked, toggleLike, remove],
   );
 
   return (

--- a/app/hooks/useLike.ts
+++ b/app/hooks/useLike.ts
@@ -1,9 +1,31 @@
 import { usePostStore } from '../contexts/PostStoreContext';
+import { likeEvents } from '../likeEvents';
+import { useEffect, useState, useCallback } from 'react';
 
 export default function useLike(id: string, isReply: boolean = false) {
-  const { posts, toggleLike } = usePostStore();
-  const likeCount = posts[id]?.likeCount ?? 0;
-  const liked = posts[id]?.liked ?? false;
-  return { likeCount, liked, toggleLike: () => toggleLike(id, isReply) };
+  const { getState, toggleLike } = usePostStore();
+  const initial = getState(id) || { likeCount: 0, liked: false };
+  const [state, setState] = useState(initial);
+
+  useEffect(() => {
+    const handler = ({ id: changedId, count, liked }: any) => {
+      if (changedId === id) {
+        setState({ likeCount: count, liked });
+      }
+    };
+    likeEvents.on('likeChanged', handler);
+    return () => {
+      likeEvents.off('likeChanged', handler);
+    };
+  }, [id]);
+
+  useEffect(() => {
+    const current = getState(id);
+    if (current) setState(current);
+  }, [getState, id]);
+
+  const toggle = useCallback(() => toggleLike(id, isReply), [toggleLike, id, isReply]);
+
+  return { likeCount: state.likeCount, liked: state.liked, toggleLike: toggle };
 }
 

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -99,7 +99,7 @@ export default function ProfileScreen() {
     removePost,
     updatePost,
   } = useAuth()!;
-  const { initialize, remove, posts: storePosts } = usePostStore();
+  const { initialize, remove, getState } = usePostStore();
 
   const [replyCounts, setReplyCounts] = useState<{ [key: string]: number }>({});
   const [replyModalVisible, setReplyModalVisible] = useState(false);
@@ -119,7 +119,7 @@ export default function ProfileScreen() {
   useEffect(() => {
     const syncLikes = async () => {
       if (myPosts && myPosts.length) {
-        const missing = myPosts.filter(p => storePosts[p.id] === undefined);
+        const missing = myPosts.filter(p => !getState(p.id));
         if (missing.length) {
           const counts = await getLikeCounts(missing.map(p => p.id));
           initialize(missing.map(p => ({ id: p.id, like_count: counts[p.id] })));
@@ -127,7 +127,7 @@ export default function ProfileScreen() {
       }
     };
     syncLikes();
-  }, [myPosts, storePosts]);
+  }, [myPosts, getState]);
 
   useEffect(() => {
     const loadCounts = async () => {


### PR DESCRIPTION
## Summary
- refactor PostStore to expose stable `getState`
- subscribe to `likeEvents` in `useLike`
- allow overriding like data in `PostCard`
- update ProfileScreen to use new store API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1cd54248322bd9c0e6cae154897