### PR TITLE
Implement improved story viewer

### DIFF
--- a/app/components/StoryViewer.tsx
+++ b/app/components/StoryViewer.tsx
@@ -1,5 +1,17 @@
-import React, { useEffect, useRef } from 'react';
-import { Modal, View, Image, StyleSheet, TouchableWithoutFeedback, Dimensions, Text, TouchableOpacity, PanResponder } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Modal,
+  View,
+  Image,
+  StyleSheet,
+  Dimensions,
+  TouchableWithoutFeedback,
+  FlatList,
+  Text,
+  Animated,
+  PanResponder,
+  TouchableOpacity,
+} from 'react-native';
 import { Video } from 'expo-av';
 import { useStories } from '../contexts/StoryContext';
 import { colors } from '../styles/colors';
@@ -7,24 +19,76 @@ import { colors } from '../styles/colors';
 const { width, height } = Dimensions.get('window');
 
 export default function StoryViewer() {
-  const { visible, stories, currentIndex, next, prev, closeViewer } = useStories();
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const {
+    visible,
+    stories,
+    currentIndex,
+    next,
+    prev,
+    closeViewer,
+    setIndex,
+    viewer,
+  } = useStories();
+
+  const flatListRef = useRef<FlatList>(null);
+  const progress = useRef(new Animated.Value(0)).current;
+  const holdProgress = useRef(0);
+  const animationRef = useRef<Animated.CompositeAnimation | null>(null);
+  const videoRef = useRef<Video | null>(null);
+  const [duration, setDuration] = useState(5000);
+
+  const startAnimation = (d: number) => {
+    progress.setValue(0);
+    setDuration(d);
+    animationRef.current?.stop();
+    animationRef.current = Animated.timing(progress, {
+      toValue: 1,
+      duration: d,
+      useNativeDriver: false,
+    });
+    animationRef.current.start(({ finished }) => {
+      if (finished) next();
+    });
+  };
 
   useEffect(() => {
     if (!visible) return;
-    timerRef.current && clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      next();
-    }, 5000);
-    return () => {
-      timerRef.current && clearTimeout(timerRef.current);
-    };
-  }, [visible, currentIndex, next]);
+    flatListRef.current?.scrollToIndex({ index: currentIndex, animated: false });
+    const story = stories[currentIndex];
+    if (!story) return;
+    if (story.media_type === 'image') {
+      startAnimation(5000);
+    }
+    if (stories[currentIndex + 1]?.media_type === 'image') {
+      Image.prefetch(stories[currentIndex + 1].media_url).catch(() => {});
+    }
+  }, [visible, currentIndex]);
+
+  const handleHold = () => {
+    animationRef.current?.stop();
+    progress.stopAnimation(v => {
+      holdProgress.current = v;
+    });
+    videoRef.current?.pauseAsync();
+  };
+
+  const handleRelease = () => {
+    const remaining = (1 - holdProgress.current) * duration;
+    animationRef.current = Animated.timing(progress, {
+      toValue: 1,
+      duration: remaining,
+      useNativeDriver: false,
+    });
+    animationRef.current.start(({ finished }) => {
+      if (finished) next();
+    });
+    videoRef.current?.playAsync();
+  };
 
   const panResponder = useRef(
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 10,
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > Math.abs(g.dx) && Math.abs(g.dy) > 10,
       onPanResponderRelease: (_, g) => {
         if (g.dy > 50) closeViewer();
       },
@@ -32,40 +96,96 @@ export default function StoryViewer() {
   ).current;
 
   if (!visible || stories.length === 0) return null;
-  const story = stories[currentIndex];
+
+  const renderItem = ({ item }: { item: any }) => (
+    <View style={styles.page}>
+      {item.media_type === 'image' ? (
+        <Image source={{ uri: item.media_url }} style={styles.media} resizeMode="cover" />
+      ) : (
+        <Video
+          ref={videoRef}
+          source={{ uri: item.media_url }}
+          style={styles.media}
+          resizeMode="contain"
+          shouldPlay
+          isMuted
+          onLoad={s => {
+            startAnimation(s.durationMillis || 5000);
+          }}
+          onPlaybackStatusUpdate={status => {
+            if (status.isLoaded && status.didJustFinish) next();
+          }}
+        />
+      )}
+      {item.overlay_text ? <Text style={styles.overlay}>{item.overlay_text}</Text> : null}
+    </View>
+  );
+
+  const onMomentumEnd = (e: any) => {
+    const i = Math.round(e.nativeEvent.contentOffset.x / width);
+    if (i !== currentIndex) setIndex(i);
+  };
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={closeViewer}>
       <View style={styles.container} {...panResponder.panHandlers}>
+        <TouchableWithoutFeedback onPressIn={handleHold} onPressOut={handleRelease}>
+          <View style={{ flex: 1 }}>
+            <View style={styles.progressRow} pointerEvents="none">
+              {stories.map((_, i) => {
+                const barStyle =
+                  i === currentIndex
+                    ? { transform: [{ scaleX: progress }] }
+                    : i < currentIndex
+                    ? { transform: [{ scaleX: 1 }] }
+                    : { transform: [{ scaleX: 0 }] };
+                return (
+                  <View key={i} style={styles.barBackground}>
+                    <Animated.View style={[styles.barForeground, barStyle]} />
+                  </View>
+                );
+              })}
+            </View>
+            <View style={styles.header}>
+              {viewer?.image_url ? (
+                <Image source={{ uri: viewer.image_url }} style={styles.avatar} />
+              ) : null}
+              {viewer?.username ? <Text style={styles.username}>{viewer.username}</Text> : null}
+            </View>
+            <FlatList
+              ref={flatListRef}
+              data={stories}
+              horizontal
+              pagingEnabled
+              onMomentumScrollEnd={onMomentumEnd}
+              showsHorizontalScrollIndicator={false}
+              keyExtractor={item => item.id}
+              renderItem={renderItem}
+            />
+            <View style={styles.touchRow} pointerEvents="box-none">
+              <TouchableWithoutFeedback onPress={prev}>
+                <View style={styles.touchArea} />
+              </TouchableWithoutFeedback>
+              <TouchableWithoutFeedback onPress={next}>
+                <View style={styles.touchArea} />
+              </TouchableWithoutFeedback>
+            </View>
+          </View>
+        </TouchableWithoutFeedback>
         <TouchableOpacity style={styles.close} onPress={closeViewer}>
           <Text style={{ color: colors.text, fontSize: 18 }}>X</Text>
         </TouchableOpacity>
-        {story.media_type === 'image' ? (
-          <Image source={{ uri: story.media_url }} style={styles.media} resizeMode="contain" />
-        ) : (
-          <Video source={{ uri: story.media_url }} style={styles.media} resizeMode="contain" shouldPlay isMuted />
-        )}
-        {story.overlay_text ? <Text style={styles.overlay}>{story.overlay_text}</Text> : null}
-        <View style={styles.touchRow} pointerEvents="box-none">
-          <TouchableWithoutFeedback onPress={prev}><View style={styles.touchArea} /></TouchableWithoutFeedback>
-          <TouchableWithoutFeedback onPress={next}><View style={styles.touchArea} /></TouchableWithoutFeedback>
-        </View>
       </View>
     </Modal>
   );
 }
 
+const BAR_HEIGHT = 2;
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: 'black',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  media: {
-    width,
-    height,
-  },
+  container: { flex: 1, backgroundColor: 'black' },
+  page: { width, height, justifyContent: 'center', alignItems: 'center' },
+  media: { width, height, resizeMode: 'contain' },
   overlay: {
     position: 'absolute',
     bottom: 80,
@@ -82,13 +202,43 @@ const styles = StyleSheet.create({
     right: 0,
     flexDirection: 'row',
   },
-  touchArea: {
-    flex: 1,
-  },
+  touchArea: { flex: 1 },
   close: {
     position: 'absolute',
     top: 40,
     right: 20,
-    zIndex: 10,
+    zIndex: 20,
   },
+  progressRow: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    right: 10,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    zIndex: 20,
+  },
+  barBackground: {
+    flex: 1,
+    height: BAR_HEIGHT,
+    backgroundColor: 'rgba(255,255,255,0.3)',
+    marginHorizontal: 2,
+    overflow: 'hidden',
+  },
+  barForeground: {
+    height: BAR_HEIGHT,
+    backgroundColor: '#fff',
+    transform: [{ scaleX: 0 }],
+    transformOrigin: 'left',
+  },
+  header: {
+    position: 'absolute',
+    top: 20,
+    left: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    zIndex: 20,
+  },
+  avatar: { width: 32, height: 32, borderRadius: 16, marginRight: 8 },
+  username: { color: '#fff', fontWeight: 'bold' },
 });

--- a/app/contexts/StoryContext.tsx
+++ b/app/contexts/StoryContext.tsx
@@ -12,22 +12,30 @@ export interface Story {
   expires_at: string;
 }
 
+export interface ViewerProfile {
+  username: string;
+  image_url: string | null;
+}
+
 interface StoryContextValue {
   openUserStories: (userId: string) => Promise<void>;
   closeViewer: () => void;
-  stories: Story[];
+  stories: (Story & { profiles?: any })[];
   visible: boolean;
   currentIndex: number;
+  viewer: ViewerProfile | null;
   next: () => void;
   prev: () => void;
+  setIndex: (index: number) => void;
 }
 
 const StoryContext = createContext<StoryContextValue | undefined>(undefined);
 
 export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [stories, setStories] = useState<Story[]>([]);
+  const [stories, setStories] = useState<(Story & { profiles?: any })[]>([]);
   const [visible, setVisible] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [viewer, setViewer] = useState<ViewerProfile | null>(null);
   const loadingRef = useRef(false);
 
   const openUserStories = useCallback(async (userId: string) => {
@@ -35,7 +43,7 @@ export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     loadingRef.current = true;
     const { data, error } = await supabase
       .from('stories')
-      .select('*')
+      .select('*, profiles(username, image_url)')
       .eq('user_id', userId)
       .gt('expires_at', new Date().toISOString())
       .order('created_at', { ascending: true });
@@ -45,7 +53,12 @@ export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       return;
     }
     if (data && data.length > 0) {
-      setStories(data as Story[]);
+      const { profiles, ...first } = data[0] as any;
+      setViewer({
+        username: profiles?.username ?? '',
+        image_url: profiles?.image_url ?? null,
+      });
+      setStories(data as any);
       setCurrentIndex(0);
       setVisible(true);
     }
@@ -55,6 +68,7 @@ export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setVisible(false);
     setStories([]);
     setCurrentIndex(0);
+    setViewer(null);
   }, []);
 
   const next = useCallback(() => {
@@ -69,14 +83,30 @@ export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setCurrentIndex(i => Math.max(0, i - 1));
   }, []);
 
+  const setIndex = useCallback(
+    (index: number) => {
+      setCurrentIndex(i => {
+        if (index < 0) return 0;
+        if (index >= stories.length) {
+          closeViewer();
+          return i;
+        }
+        return index;
+      });
+    },
+    [stories.length, closeViewer],
+  );
+
   const value: StoryContextValue = {
     openUserStories,
     closeViewer,
     stories,
     visible,
     currentIndex,
+    viewer,
     next,
     prev,
+    setIndex,
   };
 
   return (


### PR DESCRIPTION
## Summary
- fetch user profiles with stories and persist viewer info
- expose `setIndex` method and viewer profile via StoryContext
- implement new StoryViewer modal with progress bars, pause/resume, and horizontal paging

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: missing deps & config)*

------
https://chatgpt.com/codex/tasks/task_e_6857ea2c8eec8322a33dd54a46ee06f3