### PR TITLE
Add Supabase stories SQL and storage policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql` **and** `sql/marketplace.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql`, `sql/stories.sql` **and** `sql/marketplace.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `stories` table holds temporary media for user stories. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
 
 
 
-3. Create public storage buckets named `market-images`, `post-images`, `post-videos` and `reply-videos` in Supabase so listing media can be uploaded. Then run `sql/storage.sql` to allow authenticated users to upload and everyone to view files.
+3. Create public storage buckets named `market-images`, `post-images`, `post-videos`, `reply-videos` and `stories-media` in Supabase so listing media can be uploaded. Then run `sql/storage.sql` to allow authenticated users to upload and everyone to view files.
 
 
 4. Copy your project's URL and `anon` key into `lib/supabase.js`.

--- a/sql/storage.sql
+++ b/sql/storage.sql
@@ -58,3 +58,16 @@ create policy "Reply video uploads" on storage.objects
 create policy "Public reply video access" on storage.objects
   for select using (bucket_id = 'reply-videos');
 
+
+-- Policies for the stories-media storage bucket
+insert into storage.buckets (id, name, public)
+  values ('stories-media', 'stories-media', true)
+  on conflict (id) do update set public = true;
+
+create policy "Story media uploads" on storage.objects
+  for insert with check (
+    bucket_id = 'stories-media' and auth.role() = 'authenticated'
+  );
+
+create policy "Public story media access" on storage.objects
+  for select using (bucket_id = 'stories-media');

--- a/sql/stories.sql
+++ b/sql/stories.sql
@@ -1,0 +1,25 @@
+-- Table for user stories
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.stories (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  url text not null,
+  caption text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.stories enable row level security;
+
+-- Only the owner can create/read/delete stories for now
+create policy "Users can insert stories"
+  on public.stories for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can read their stories"
+  on public.stories for select
+  using (auth.uid() = user_id);
+
+create policy "Users can delete their stories"
+  on public.stories for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create `sql/stories.sql` for story posts
- allow uploads to new `stories-media` bucket
- update setup instructions for stories table and bucket

## Testing
- `npm test` *(fails: Missing script & network access)*

------
https://chatgpt.com/codex/tasks/task_e_68594288aa688322a4897a9d5449bf11