### PR TITLE
Add swipe-close and restricted story deletion

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './AuthContext';
 import Navigator from './Navigator';
 import { PostStoreProvider } from './app/contexts/PostStoreContext';
+import { StoryStoreProvider } from './app/contexts/StoryStoreContext';
 
 import { Buffer } from 'buffer';
 import process from 'process';
@@ -14,9 +15,11 @@ export default function App() {
   return (
     <AuthProvider>
       <PostStoreProvider>
-        <NavigationContainer>
-          <Navigator />
-        </NavigationContainer>
+        <StoryStoreProvider>
+          <NavigationContainer>
+            <Navigator />
+          </NavigationContainer>
+        </StoryStoreProvider>
       </PostStoreProvider>
     </AuthProvider>
   );

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -168,6 +168,11 @@ export default function TopTabsNavigator() {
     setModalVisible(false);
   };
 
+  const handleAddStory = () => {
+    setModalVisible(false);
+    navigation.navigate('CreateStory');
+  };
+
   const displayName = profile?.name || profile?.username;
   const welcomeText = displayName
     ? `Welcome @${displayName}`
@@ -282,6 +287,7 @@ export default function TopTabsNavigator() {
               <View style={styles.buttonRow}>
                 <Button title="Add Image" onPress={pickImage} />
                 <Button title="Add Video" onPress={pickVideo} />
+                <Button title="Add Story" onPress={handleAddStory} />
                 <Button title="Post" onPress={handleModalPost} />
               </View>
               <Button title="Cancel" onPress={() => setModalVisible(false)} />

--- a/app/contexts/StoryStoreContext.tsx
+++ b/app/contexts/StoryStoreContext.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface Story {
+  id: string;
+  userId: string;
+  imageUri?: string;
+  videoUri?: string;
+  createdAt: string;
+}
+
+interface StoryStore {
+  stories: Story[];
+  addStory: (story: Story) => Promise<void>;
+  removeStory: (storyId: string) => void;
+  getStoriesForUser: (userId: string) => Story[];
+}
+
+const StoryStoreContext = createContext<StoryStore | undefined>(undefined);
+
+export const StoryStoreProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [stories, setStories] = useState<Story[]>([]);
+
+  useEffect(() => {
+    AsyncStorage.getItem('stories').then(stored => {
+      if (stored) {
+        try {
+          setStories(JSON.parse(stored));
+        } catch {}
+      }
+    });
+  }, []);
+
+  const addStory = useCallback(async (story: Story) => {
+    setStories(prev => {
+      const updated = [story, ...prev];
+      AsyncStorage.setItem('stories', JSON.stringify(updated));
+      return updated;
+    });
+  }, []);
+
+  const removeStory = useCallback((storyId: string) => {
+    setStories(prev => {
+      const updated = prev.filter(s => s.id !== storyId);
+      AsyncStorage.setItem('stories', JSON.stringify(updated));
+      return updated;
+    });
+  }, []);
+
+  const getStoriesForUser = useCallback(
+    (userId: string) => stories.filter(s => s.userId === userId),
+    [stories],
+  );
+
+  return (
+    <StoryStoreContext.Provider
+      value={{ stories, addStory, removeStory, getStoriesForUser }}
+    >
+      {children}
+    </StoryStoreContext.Provider>
+  );
+};
+
+export function useStories() {
+  const ctx = useContext(StoryStoreContext);
+  if (!ctx) throw new Error('useStories must be used within StoryStoreProvider');
+  return ctx;
+}

--- a/app/screens/CreateStoryScreen.tsx
+++ b/app/screens/CreateStoryScreen.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Button, Image } from 'react-native';
+import { Video } from 'expo-av';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
+import { useNavigation } from '@react-navigation/native';
+import { useAuth } from '../../AuthContext';
+import { uploadImage } from '../../lib/uploadImage';
+import { supabase, POST_VIDEO_BUCKET } from '../../lib/supabase';
+import { useStories } from '../contexts/StoryStoreContext';
+import { colors } from '../styles/colors';
+
+export default function CreateStoryScreen() {
+  const navigation = useNavigation<any>();
+  const { user } = useAuth()!;
+  const { addStory } = useStories();
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [videoUri, setVideoUri] = useState<string | null>(null);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      setImageUri(result.assets[0].uri);
+      setVideoUri(null);
+    }
+  };
+
+  const pickVideo = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.size && info.size > 20 * 1024 * 1024) {
+        // eslint-disable-next-line no-alert
+        alert('Video too large, please select one under 20MB.');
+        return;
+      }
+      setVideoUri(uri);
+      setImageUri(null);
+    }
+  };
+
+  const handlePost = async () => {
+    if (!user || (!imageUri && !videoUri)) {
+      navigation.goBack();
+      return;
+    }
+    let uploadedImage: string | undefined;
+    let uploadedVideo: string | undefined;
+    if (imageUri) {
+      uploadedImage = await uploadImage(imageUri, user.id) || imageUri;
+    }
+    if (videoUri) {
+      try {
+        const ext = videoUri.split('.').pop() || 'mp4';
+        const path = `${user.id}-${Date.now()}.${ext}`;
+        const resp = await fetch(videoUri);
+        const blob = await resp.blob();
+        const { error } = await supabase.storage.from(POST_VIDEO_BUCKET).upload(path, blob);
+        if (!error) {
+          const { publicURL } = supabase.storage.from(POST_VIDEO_BUCKET).getPublicUrl(path);
+          uploadedVideo = publicURL || videoUri;
+        } else {
+          uploadedVideo = videoUri;
+        }
+      } catch {
+        uploadedVideo = videoUri;
+      }
+    }
+    await addStory({
+      id: `story-${Date.now()}`,
+      userId: user.id,
+      imageUri: uploadedImage,
+      videoUri: uploadedVideo,
+      createdAt: new Date().toISOString(),
+    });
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Create a new story</Text>
+      {imageUri && <Image source={{ uri: imageUri }} style={styles.preview} />}
+      {!imageUri && videoUri && (
+        <Video
+          source={{ uri: videoUri }}
+          style={styles.preview}
+          useNativeControls
+          isMuted
+          resizeMode="contain"
+        />
+      )}
+      <View style={styles.buttonRow}>
+        <Button title="Add Image" onPress={pickImage} />
+        <Button title="Add Video" onPress={pickVideo} />
+      </View>
+      <View style={styles.buttonRow}>
+        <Button title="Cancel" onPress={() => navigation.goBack()} />
+        <Button title="Post" onPress={handlePost} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+    padding: 20,
+  },
+  text: { color: colors.text, fontSize: 18, marginBottom: 20 },
+  preview: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+});

--- a/app/screens/FollowingFeedScreen.jsx
+++ b/app/screens/FollowingFeedScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import PostCard from '../components/PostCard';
+import { useStories } from '../contexts/StoryStoreContext';
 
 const PostItem = React.memo(function PostItem({
   item,
@@ -44,12 +45,23 @@ const PAGE_SIZE = 10;
 export default function FollowingFeedScreen() {
   const { user, profileImageUri } = useAuth();
   const navigation = useNavigation();
+  const { getStoriesForUser } = useStories();
   const { initialize } = usePostStore();
   const [posts, setPosts] = useState([]);
   const [replyCounts, setReplyCounts] = useState({});
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+
+  const navigateToProfileOrStory = (targetId, isMe) => {
+    const stories = getStoriesForUser(targetId);
+    if (stories.length > 0) {
+      navigation.navigate('StoryView', { userId: targetId });
+    } else {
+      if (isMe) navigation.navigate('Profile');
+      else navigation.navigate('OtherUserProfile', { userId: targetId });
+    }
+  };
 
   const fetchPosts = useCallback(async (offset = 0, append = false) => {
 
@@ -169,11 +181,7 @@ export default function FollowingFeedScreen() {
               videoUrl={item.video_url || undefined}
               replyCount={replyCounts[item.id] || 0}
               onPress={() => navigation.navigate('PostDetail', { post: item })}
-              onProfilePress={() =>
-                isMe
-                  ? navigation.navigate('Profile')
-                  : navigation.navigate('OtherUserProfile', { userId: item.user_id })
-              }
+              onProfilePress={() => navigateToProfileOrStory(item.user_id, isMe)}
               onOpenReplies={() => navigation.navigate('PostDetail', { post: item })}
             />
           );

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -30,6 +30,8 @@ import {
 import { uploadImage } from '../../lib/uploadImage';
 import ReplyModal from '../components/ReplyModal';
 
+import { useStories } from '../contexts/StoryStoreContext';
+
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAuth } from '../../AuthContext';
@@ -75,6 +77,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
   const listRef = useRef<FlatList>(null);
   const [replyModalVisible, setReplyModalVisible] = useState(false);
   const [activePostId, setActivePostId] = useState<string | null>(null);
+  const { getStoriesForUser } = useStories();
 
   const [searchVisible, setSearchVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -99,6 +102,16 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
       }
     }
     return result;
+  };
+
+  const navigateToProfileOrStory = (targetId: string, isMe: boolean) => {
+    const stories = getStoriesForUser(targetId);
+    if (stories.length > 0) {
+      navigation.navigate('StoryView', { userId: targetId });
+    } else {
+      if (isMe) navigation.navigate('Profile');
+      else navigation.navigate('OtherUserProfile', { userId: targetId });
+    }
   };
 
   useEffect(() => {
@@ -490,11 +503,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
                 replyCount={item.reply_count ?? 0}
                 onLike={() => handleLike(item.id)}
                 onPress={() => navigation.navigate('PostDetail', { post: item })}
-                onProfilePress={() =>
-                  isMe
-                    ? navigation.navigate('Profile')
-                    : navigation.navigate('OtherUserProfile', { userId: item.user_id })
-                }
+                onProfilePress={() => navigateToProfileOrStory(item.user_id, isMe)}
                 onDelete={() => confirmDeletePost(item.id)}
                 onOpenReplies={() => openReplyModal(item.id)}
               />
@@ -555,11 +564,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
                           ancestors: [],
                         })
                       }
-                      onProfilePress={() =>
-                        isMe
-                          ? navigation.navigate('Profile')
-                          : navigation.navigate('OtherUserProfile', { userId: reply.user_id })
-                      }
+                      onProfilePress={() => navigateToProfileOrStory(reply.user_id, isMe)}
                       onDelete={() => {}}
                       onOpenReplies={() => {}}
                     />
@@ -577,11 +582,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
                     replyCount={post.reply_count ?? 0}
                     onLike={() => handleLike(post.id)}
                     onPress={() => navigation.navigate('PostDetail', { post })}
-                    onProfilePress={() =>
-                      isMe
-                        ? navigation.navigate('Profile')
-                        : navigation.navigate('OtherUserProfile', { userId: post.user_id })
-                    }
+                    onProfilePress={() => navigateToProfileOrStory(post.user_id, isMe)}
                     onDelete={() => {}}
                     onOpenReplies={() => {}}
                   />

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -25,6 +25,7 @@ import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
 import { replyEvents } from '../replyEvents';
 import { usePostStore } from '../contexts/PostStoreContext';
+import { useStories } from '../contexts/StoryStoreContext';
 import { postEvents } from '../postEvents';
 import PostCard, { Post } from '../components/PostCard';
 import { CONFIRM_ACTION } from '../constants/ui';
@@ -71,6 +72,7 @@ export default function PostDetailScreen() {
     bannerImageUri,
     removePost,
   } = useAuth()!;
+  const { getStoriesForUser } = useStories();
   const { initialize, remove } = usePostStore();
   const post = route.params.post as Post;
   const fromProfile = route.params?.fromProfile ?? false;
@@ -89,6 +91,16 @@ export default function PostDetailScreen() {
 
 
   const [keyboardOffset, setKeyboardOffset] = useState(0);
+
+  const navigateToProfileOrStory = (targetId: string, isMe: boolean) => {
+    const stories = getStoriesForUser(targetId);
+    if (stories.length > 0) {
+      navigation.navigate('StoryView', { userId: targetId });
+    } else {
+      if (isMe) navigation.navigate('Profile');
+      else navigation.navigate('OtherUserProfile', { userId: targetId });
+    }
+  };
 
   const confirmDeletePost = (id: string) => {
     Alert.alert('Delete Post', 'Are you sure you want to delete this post?', [
@@ -581,13 +593,7 @@ export default function PostDetailScreen() {
             videoUrl={post.video_url ?? undefined}
             replyCount={replyCounts[post.id] || 0}
             onPress={() => {}}
-            onProfilePress={() =>
-              user?.id === post.user_id
-                ? navigation.navigate('Profile')
-                : navigation.navigate('OtherUserProfile', {
-                    userId: post.user_id,
-                  })
-            }
+            onProfilePress={() => navigateToProfileOrStory(post.user_id, user?.id === post.user_id)}
             
             onDelete={() => confirmDeletePost(post.id)}
             onOpenReplies={() => openQuickReplyModal(post.id, null)}
@@ -618,13 +624,7 @@ export default function PostDetailScreen() {
                   ancestors: [],
                 })
               }
-              onProfilePress={() =>
-                isMe
-                  ? navigation.navigate('Profile')
-                  : navigation.navigate('OtherUserProfile', {
-                      userId: item.user_id,
-                    })
-              }
+              onProfilePress={() => navigateToProfileOrStory(item.user_id, isMe)}
               onDelete={() => confirmDeleteReply(item.id)}
               onOpenReplies={() => openQuickReplyModal(post.id, item.id)}
             />

--- a/app/screens/StoryViewScreen.tsx
+++ b/app/screens/StoryViewScreen.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useRef } from 'react';
+  import {
+    View,
+    StyleSheet,
+    Image,
+    Button,
+    Pressable,
+    Text,
+    Alert,
+    TouchableOpacity,
+    PanResponder,
+  } from 'react-native';
+import { Video } from 'expo-av';
+import { useRoute, useNavigation } from '@react-navigation/native';
+import { colors } from '../styles/colors';
+import { useStories } from '../contexts/StoryStoreContext';
+import { useAuth } from '../../AuthContext';
+
+export default function StoryViewScreen() {
+  const route = useRoute<any>();
+  const navigation = useNavigation<any>();
+  const { user } = useAuth()!;
+  const { userId } = route.params as { userId: string };
+  const { getStoriesForUser, removeStory } = useStories();
+  const stories = getStoriesForUser(userId);
+  const [index, setIndex] = useState(0);
+  const story = stories[index];
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 20,
+      onPanResponderRelease: (_, g) => {
+        if (g.dy > 50) navigation.goBack();
+      },
+    }),
+  ).current;
+
+  const next = () => {
+    if (index < stories.length - 1) {
+      setIndex(i => i + 1);
+    }
+  };
+
+  const prev = () => {
+    if (index > 0) {
+      setIndex(i => i - 1);
+    }
+  };
+
+  const confirmDelete = () => {
+    if (!story) return;
+    if (!user || user.id !== story.userId) return;
+    Alert.alert(
+      'Are you sure you want to delete this story?',
+      '',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            removeStory(story.id);
+            const remaining = stories.filter((_, i) => i !== index);
+            if (remaining.length === 0) {
+              navigation.goBack();
+              return;
+            }
+            if (index >= remaining.length) {
+              setIndex(remaining.length - 1);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.mediaContainer} {...panResponder.panHandlers}>
+        <Text style={styles.counter}>{`${index + 1}/${stories.length}`}</Text>
+        {user && story?.userId === user.id && (
+          <TouchableOpacity style={styles.deleteBtn} onPress={confirmDelete}>
+            <Text style={styles.deleteText}>X</Text>
+          </TouchableOpacity>
+        )}
+        {story?.imageUri && (
+          <Image source={{ uri: story.imageUri }} style={styles.media} />
+        )}
+        {!story?.imageUri && story?.videoUri && (
+          <Video
+            source={{ uri: story.videoUri }}
+            style={styles.media}
+            resizeMode="contain"
+            shouldPlay
+          />
+        )}
+        <Pressable style={styles.leftZone} onPress={prev} />
+        <Pressable style={styles.rightZone} onPress={next} />
+      </View>
+      <Button title="Close" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.background },
+  mediaContainer: { width: '100%', height: '80%', justifyContent: 'center', alignItems: 'center' },
+  media: { width: '100%', height: '100%', borderRadius: 6 },
+  leftZone: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: '50%',
+  },
+  rightZone: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    right: 0,
+    width: '50%',
+  },
+  counter: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    color: colors.text,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    zIndex: 2,
+  },
+  deleteBtn: { position: 'absolute', top: 10, right: 10, padding: 6, zIndex: 2 },
+  deleteText: { color: colors.text, fontSize: 18 },
+});

--- a/bottomtabs/BottomTabsNavigator.js
+++ b/bottomtabs/BottomTabsNavigator.js
@@ -34,6 +34,12 @@ const OtherUserProfileScreen = React.lazy(() =>
 const FollowListScreen = React.lazy(() =>
   import('../app/screens/FollowListScreen'),
 );
+const CreateStoryScreen = React.lazy(() =>
+  import('../app/screens/CreateStoryScreen'),
+);
+const StoryViewScreen = React.lazy(() =>
+  import('../app/screens/StoryViewScreen'),
+);
 const { height } = Dimensions.get('window');
 
 function HomeStackScreen() {
@@ -47,6 +53,8 @@ function HomeStackScreen() {
         <Stack.Screen name="UserProfile" component={UserProfileScreen} />
         <Stack.Screen name="OtherUserProfile" component={OtherUserProfileScreen} />
         <Stack.Screen name="FollowList" component={FollowListScreen} />
+        <Stack.Screen name="CreateStory" component={CreateStoryScreen} />
+        <Stack.Screen name="StoryView" component={StoryViewScreen} />
       </Stack.Navigator>
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- restrict deleting stories to their owner in `StoryViewScreen`
- add vertical swipe gesture to close the story viewer

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails to compile: missing modules and JSX errors)*


------
https://chatgpt.com/codex/tasks/task_e_685a7dc0674c8322a6a4998a7900d8df