### PR TITLE
Expand profile banner images to screen width

### DIFF
--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -202,7 +202,7 @@ const styles = StyleSheet.create({
   },
   backButton: { alignSelf: 'flex-start', marginBottom: 20 },
   profileRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
-  banner: { width: '100%', height: 200, marginBottom: 20 },
+  banner: { width: '100%', height: 200, marginBottom: 20, marginHorizontal: -20 },
   avatar: { width: 80, height: 80, borderRadius: 40 },
   placeholder: { backgroundColor: '#555' },
   textContainer: { marginLeft: 15 },

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -700,6 +700,7 @@ const styles = StyleSheet.create({
     width: '100%',
     height: Dimensions.get('window').height * 0.25,
     marginBottom: 20,
+    marginHorizontal: -20,
   },
   avatar: {
     width: 80,


### PR DESCRIPTION
## Summary
- allow profile banner images to span the full screen width by adding negative horizontal margin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aa5e1815c8322b8f7f7ec646f63c4