### PR TITLE
Expand profile banner images to screen width

### DIFF
--- a/app/screens/OtherUserProfileScreen.jsx
+++ b/app/screens/OtherUserProfileScreen.jsx
@@ -119,7 +119,11 @@ export default function OtherUserProfileScreen() {
     <View style={styles.headerContainer}>
 
       {profile.banner_url ? (
-        <Image source={{ uri: profile.banner_url }} style={styles.banner} />
+        <Image
+          source={{ uri: profile.banner_url }}
+          style={styles.banner}
+          resizeMode="contain"
+        />
       ) : (
         <View style={[styles.banner, styles.placeholder]} />
       )}
@@ -202,7 +206,7 @@ const styles = StyleSheet.create({
   },
   backButton: { alignSelf: 'flex-start', marginBottom: 20 },
   profileRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
-  banner: { width: '100%', height: 200, marginBottom: 20 },
+  banner: { width: '100%', height: 200, marginBottom: 20, marginHorizontal: -20 },
   avatar: { width: 80, height: 80, borderRadius: 40 },
   placeholder: { backgroundColor: '#555' },
   textContainer: { marginLeft: 15 },

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -494,7 +494,11 @@ export default function ProfileScreen() {
   const renderHeader = () => (
     <View style={styles.headerContainer}>
       {bannerImageUri ? (
-        <Image source={{ uri: bannerImageUri }} style={styles.banner} />
+        <Image
+          source={{ uri: bannerImageUri }}
+          style={styles.banner}
+          resizeMode="contain"
+        />
       ) : (
         <View style={[styles.banner, styles.placeholder]} />
       )}
@@ -700,6 +704,7 @@ const styles = StyleSheet.create({
     width: '100%',
     height: Dimensions.get('window').height * 0.25,
     marginBottom: 20,
+    marginHorizontal: -20,
   },
   avatar: {
     width: 80,

--- a/app/screens/StoryViewScreen.tsx
+++ b/app/screens/StoryViewScreen.tsx
@@ -3,7 +3,6 @@ import React, { useState, useRef } from 'react';
     View,
     StyleSheet,
     Image,
-    Button,
     Pressable,
     Text,
     Alert,
@@ -94,7 +93,11 @@ export default function StoryViewScreen() {
         )}
 
         {story?.imageUri && (
-          <Image source={{ uri: story.imageUri }} style={styles.media} />
+          <Image
+            source={{ uri: story.imageUri }}
+            style={styles.media}
+            resizeMode="contain"
+          />
         )}
         {!story?.imageUri && story?.videoUri && (
           <Video
@@ -108,7 +111,13 @@ export default function StoryViewScreen() {
         <Pressable style={styles.rightZone} onPress={next} />
       </View>
 
-      <Button title="Close" onPress={() => navigation.goBack()} />
+      <TouchableOpacity
+        style={styles.closeButton}
+        onPress={() => navigation.goBack()}
+        activeOpacity={0.8}
+      >
+        <Text style={styles.closeText}>Close</Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -144,5 +153,15 @@ const styles = StyleSheet.create({
   },
   deleteBtn: { position: 'absolute', top: 10, right: 10, padding: 6, zIndex: 2 },
   deleteText: { color: colors.text, fontSize: 18 },
+  closeButton: {
+    position: 'absolute',
+    bottom: '10%',
+    alignSelf: 'center',
+    padding: 10,
+    backgroundColor: colors.background,
+    borderRadius: 6,
+    zIndex: 2,
+  },
+  closeText: { color: colors.text, fontSize: 18 },
 
 });

--- a/app/screens/UserProfileScreen.tsx
+++ b/app/screens/UserProfileScreen.tsx
@@ -232,6 +232,7 @@ export default function UserProfileScreen() {
           <Image
             source={{ uri: profile?.banner_url || bannerUrl! }}
             style={styles.banner}
+            resizeMode="contain"
           />
         ) : (
           <View style={[styles.banner, styles.placeholder]} />
@@ -288,6 +289,7 @@ export default function UserProfileScreen() {
           <Image
             source={{ uri: profile?.banner_url || bannerUrl! }}
             style={styles.banner}
+            resizeMode="contain"
           />
         ) : (
           <View style={[styles.banner, styles.placeholder]} />
@@ -347,6 +349,7 @@ export default function UserProfileScreen() {
         <Image
           source={{ uri: profile.banner_url || bannerUrl! }}
           style={styles.banner}
+          resizeMode="contain"
         />
 
       ) : (


### PR DESCRIPTION
## Summary
- allow profile banner images to span the full screen width by adding negative horizontal margin
- ensure banner images use `resizeMode="contain"` so the whole image is visible
- overlay the StoryView close button above the media at bottom of the screen
- update StoryView image display so pictures resize to fit without cropping and bump the close button up 10%

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_685aa5e1815c8322b8f7f7ec646f63c4