### PR TITLE
Adjust HomeScreen padding for full-width media

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -631,13 +631,19 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
 });
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.background, padding: 10 },
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    paddingTop: 10,
+    paddingBottom: 10,
+  },
   input: {
     backgroundColor: '#111',
     color: '#fff',
     padding: 10,
     marginBottom: 10,
     borderRadius: 5,
+    marginHorizontal: 10,
   },
   searchContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- remove horizontal padding on `HomeScreen` container
- give the input field its own horizontal margin

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685c38a16cd48322974e8e1e8a05aeb7