### PR TITLE
Adjust bottom tab safe area

### DIFF
--- a/bottomtabs/BottomTabsNavigator.js
+++ b/bottomtabs/BottomTabsNavigator.js
@@ -73,6 +73,7 @@ export default function BottomTabsNavigator() {
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
+        safeAreaInsets: { bottom: 0 },
         headerShown: false,
         tabBarShowLabel: true,
         tabBarLabelStyle: { fontSize: 12, marginBottom: 4, color: colors.text },


### PR DESCRIPTION
## Summary
- remove bottom safe area inset so the tab bar sits flush with the bottom

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c3e201328832286a690dbeeecfaaf