### PR TITLE
Adjust bottom safe area

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -218,7 +218,7 @@ export default function TopTabsNavigator() {
   return (
     <SafeAreaView
       style={{ flex: 1, backgroundColor: colors.background }}
-      edges={['bottom']}
+      edges={[]}
     >
       <Animated.View style={{ flex: 1, transform: [{ translateX }] }}>
         <Tab.Navigator

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -500,7 +500,7 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
           data={posts}
           keyExtractor={item => item.id}
           style={{ flex: 1 }}
-          contentContainerStyle={{ paddingBottom: BOTTOM_NAV_HEIGHT }}
+          contentContainerStyle={{ paddingBottom: 0 }}
           ListHeaderComponent={<View style={{ height: 200 }} pointerEvents="none" />}
 
           removeClippedSubviews={false}


### PR DESCRIPTION
## Summary
- remove bottom edge inset from `TopTabsNavigator`
- remove list bottom padding in `HomeScreen` so posts scroll beneath the nav bar

## Testing
- `npx tsc -noEmit` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685c4df7b6cc8322aa2860d861c1a09a