### PR TITLE
Add avatar header button and drawer logout

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -56,12 +56,12 @@ function HeaderTabBar(
   props: MaterialTopTabBarProps & {
     insetsTop: number;
     welcomeText: string;
-    signOut: () => void;
+    avatarUri?: string | null;
     onProfile: () => void;
     onSearch: () => void;
   },
 ) {
-  const { insetsTop, welcomeText, signOut, onProfile, onSearch, ...barProps } = props;
+  const { insetsTop, welcomeText, avatarUri, onProfile, onSearch, ...barProps } = props;
   return (
     <BlurView
       intensity={25}
@@ -81,8 +81,13 @@ function HeaderTabBar(
       </View>
       <Text style={{ color: colors.text, textAlign: 'center' }}>{welcomeText}</Text>
       <View style={{ flexDirection: 'row', justifyContent: 'center', marginTop: 10 }}>
-        <Button title="Profile" onPress={onProfile} />
-        <Button title="Logout" onPress={signOut} />
+        <TouchableOpacity onPress={onProfile}>
+          {avatarUri ? (
+            <Image source={{ uri: avatarUri }} style={styles.avatar} />
+          ) : (
+            <Ionicons name="person-circle-outline" size={32} color={colors.accent} />
+          )}
+        </TouchableOpacity>
       </View>
       <MaterialTopTabBar
         {...barProps}
@@ -93,7 +98,7 @@ function HeaderTabBar(
 }
 
 export default function TopTabsNavigator() {
-  const { profile, user, signOut } = useAuth()!;
+  const { profile, user, signOut, profileImageUri } = useAuth()!;
   
 
   const insets = useSafeAreaInsets();
@@ -227,7 +232,7 @@ export default function TopTabsNavigator() {
               {...props}
               insetsTop={insets.top}
               welcomeText={welcomeText}
-              signOut={signOut}
+              avatarUri={profileImageUri ?? profile?.image_url ?? undefined}
               onProfile={openDrawer}
               onSearch={() => homeScreenRef.current?.openSearch()}
             />
@@ -323,6 +328,14 @@ export default function TopTabsNavigator() {
         >
           <Text style={styles.menuItem}>Direct Messages</Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => {
+            closeDrawer();
+            signOut();
+          }}
+        >
+          <Text style={styles.menuItem}>Logout</Text>
+        </TouchableOpacity>
       </Animated.View>
     </SafeAreaView>
   );
@@ -393,6 +406,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   searchButton: { position: 'absolute', right: 0, padding: 4 },
+  avatar: { width: 32, height: 32, borderRadius: 16, marginHorizontal: 8 },
 
 
   blurredBar: {


### PR DESCRIPTION
## Summary
- display the user avatar in the main header instead of a text Profile button
- move the Logout action into the slide-out drawer below the Direct Messages link

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c5537f5488322a77304bfab3518d0