### PR TITLE
Add post detail chevron

### DIFF
--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -55,20 +55,14 @@ const DRAWER_WIDTH = SCREEN_WIDTH * 0.8;
 function HeaderTabBar(
   props: MaterialTopTabBarProps & {
     insetsTop: number;
-<<<<<<< s6kyq1-codex/update-header-with-user-avatar-and-move-logout
-=======
 
->>>>>>> main
     avatarUri?: string | null;
     onProfile: () => void;
     onSearch: () => void;
   },
 ) {
   const { insetsTop, avatarUri, onProfile, onSearch, ...barProps } = props;
-<<<<<<< s6kyq1-codex/update-header-with-user-avatar-and-move-logout
-=======
 
->>>>>>> main
   return (
     <BlurView
       intensity={25}
@@ -93,10 +87,7 @@ function HeaderTabBar(
           <Ionicons name="search" size={24} color={colors.accent} />
         </TouchableOpacity>
       </View>
-<<<<<<< s6kyq1-codex/update-header-with-user-avatar-and-move-logout
-=======
 
->>>>>>> main
       <MaterialTopTabBar
         {...barProps}
         style={[barProps.style, styles.blurredBar]}
@@ -233,10 +224,7 @@ export default function TopTabsNavigator() {
             <HeaderTabBar
               {...props}
               insetsTop={insets.top}
-<<<<<<< s6kyq1-codex/update-header-with-user-avatar-and-move-logout
-=======
 
->>>>>>> main
               avatarUri={profileImageUri ?? profile?.image_url ?? undefined}
               onProfile={openDrawer}
               onSearch={() => homeScreenRef.current?.openSearch()}
@@ -413,10 +401,7 @@ const styles = StyleSheet.create({
   searchButton: { position: 'absolute', right: 0, padding: 4 },
   avatarButton: { position: 'absolute', left: 0, padding: 4 },
   avatar: { width: 40, height: 40, borderRadius: 20 },
-<<<<<<< s6kyq1-codex/update-header-with-user-avatar-and-move-logout
-=======
 
->>>>>>> main
 
 
   blurredBar: {


### PR DESCRIPTION
## Summary
- add navigation hook in MediaPostCard
- add double chevron button linking to PostDetail screen
- keep chevrons tightly grouped
- remove reply count next to the chevron
- show reply count beside the reply bubble
- hook up quick replies from MediaPostCard to store replies in Supabase and update counts

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find modules / TS config)*

------
https://chatgpt.com/codex/tasks/task_e_685c5e4c898c8322ac7305220ecb64b7