### PR TITLE
Fix Signal utilities

### DIFF
--- a/utils/signal/SignalContext.tsx
+++ b/utils/signal/SignalContext.tsx
@@ -1,14 +1,14 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import PersistentSignalStore from '../lib/PersistentSignalStore'; // adjust path if needed
+import SignalStore from './SignalStore';
 
-export const SignalContext = createContext<any>(null);
+export const SignalContext = createContext<SignalStore | null>(null);
 
 export const SignalProvider = ({ children }: { children: React.ReactNode }) => {
-  const [signalStore, setSignalStore] = useState(null);
+  const [signalStore, setSignalStore] = useState<SignalStore | null>(null);
 
   useEffect(() => {
     const init = async () => {
-      const store = await PersistentSignalStore.initFromStorage();
+      const store = await SignalStore.initFromStorage();
       setSignalStore(store);
     };
     init();

--- a/utils/signal/SignalStore.ts
+++ b/utils/signal/SignalStore.ts
@@ -1,5 +1,5 @@
 import EncryptedStorage from 'react-native-encrypted-storage';
-import * as libsignal from 'libsignal';
+import * as libsignal from '@privacyresearch/libsignal-protocol-typescript';
 
 const SESSION_PREFIX = 'session_';
 const IDENTITY_KEY = 'identityKey';
@@ -7,7 +7,7 @@ const REGISTRATION_ID = 'registrationId';
 const SIGNED_PREKEY = 'signedPreKey';
 const PREKEYS = 'preKeys';
 
-class PersistentSignalStore {
+export default class SignalStore {
   identityKeyPair: any;
   registrationId: number;
   signedPreKey: any;
@@ -28,7 +28,7 @@ class PersistentSignalStore {
     const signedPreKey = JSON.parse(await EncryptedStorage.getItem(SIGNED_PREKEY));
     const preKeys = JSON.parse(await EncryptedStorage.getItem(PREKEYS));
 
-    return new PersistentSignalStore(identityKey, registrationId, signedPreKey, preKeys);
+    return new SignalStore(identityKey, registrationId, signedPreKey, preKeys);
   }
 
   async saveSession(address: libsignal.SignalProtocolAddress, record: any) {

--- a/utils/signal/createSession.ts
+++ b/utils/signal/createSession.ts
@@ -1,12 +1,9 @@
-import {
-  SessionBuilder,
-  SessionCipher,
-} from 'libsignal';
+import * as libsignal from '@privacyresearch/libsignal-protocol-typescript';
 
-async function createSignalSessionWith(recipientId: string, recipientBundle: any, signalStore: any) {
+export async function createSignalSessionWith(recipientId: string, recipientBundle: any, signalStore: any) {
   const address = new libsignal.SignalProtocolAddress(recipientId, 1); // device ID usually 1
 
-  const builder = new SessionBuilder(signalStore, address);
+  const builder = new libsignal.SessionBuilder(signalStore, address);
   await builder.processPreKey({
     registrationId: recipientBundle.registrationId,
     identityKey: recipientBundle.identityKey,

--- a/utils/signal/decryptMessage.ts
+++ b/utils/signal/decryptMessage.ts
@@ -1,4 +1,6 @@
-async function decryptMessageFrom(
+import * as libsignal from '@privacyresearch/libsignal-protocol-typescript';
+
+export async function decryptMessageFrom(
   senderId: string,
   encrypted: { type: number, body: string },
   signalStore: any
@@ -21,4 +23,13 @@ async function decryptMessageFrom(
 
   const plaintext = new TextDecoder().decode(plaintextBytes);
   return plaintext;
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
 }

--- a/utils/signal/encryptMessage.ts
+++ b/utils/signal/encryptMessage.ts
@@ -1,6 +1,8 @@
-async function encryptMessageTo(recipientId: string, plaintext: string, signalStore: any) {
+import * as libsignal from '@privacyresearch/libsignal-protocol-typescript';
+
+export async function encryptMessageTo(recipientId: string, plaintext: string, signalStore: any) {
   const address = new libsignal.SignalProtocolAddress(recipientId, 1);
-  const cipher = new SessionCipher(signalStore, address);
+  const cipher = new libsignal.SessionCipher(signalStore, address);
 
   const ciphertext = await cipher.encrypt(plaintext);
 
@@ -9,4 +11,8 @@ async function encryptMessageTo(recipientId: string, plaintext: string, signalSt
     type: ciphertext.type,
     body: arrayBufferToBase64(ciphertext.body)
   };
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
 }

--- a/utils/signal/fetchKeyBundle.ts
+++ b/utils/signal/fetchKeyBundle.ts
@@ -1,4 +1,6 @@
-async function fetchKeyBundleForUser(recipientId: string) {
+import { supabase } from '../../lib/supabase';
+
+export async function fetchKeyBundleForUser(recipientId: string) {
   const { data, error } = await supabase
     .from('signal_key_bundles')
     .select('*')

--- a/utils/signal/initKeys.ts
+++ b/utils/signal/initKeys.ts
@@ -1,8 +1,7 @@
-import { uploadKeyBundle } from './utils/signal/uploadKeyBundle';
+import initializeKeys from './initializeKeys';
+import { uploadKeyBundle } from './uploadKeyBundle';
 
-await uploadKeyBundle(user.id, {
-  identityKey: identityKeyPair.publicKey,
-  registrationId,
-  signedPreKey,
-  preKeys
-});
+export default async function initKeys(userId: string) {
+  const publicBundle = await initializeKeys();
+  await uploadKeyBundle(userId, publicBundle);
+}

--- a/utils/signal/initializeKeys.ts
+++ b/utils/signal/initializeKeys.ts
@@ -1,7 +1,7 @@
-import * as libsignal from 'libsignal';
+import * as libsignal from '@privacyresearch/libsignal-protocol-typescript';
 import EncryptedStorage from 'react-native-encrypted-storage';
 
-async function generateAndStoreSignalKeys() {
+export default async function initializeKeys() {
   // 1. Identity
   const identityKeyPair = await libsignal.KeyHelper.generateIdentityKeyPair();
   const registrationId = await libsignal.KeyHelper.generateRegistrationId();
@@ -44,6 +44,6 @@ async function generateAndStoreSignalKeys() {
 }
 
 // helper
-function arrayBufferToBase64(buffer) {
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return btoa(String.fromCharCode(...new Uint8Array(buffer)));
 }

--- a/utils/signal/signalProvider.tsx
+++ b/utils/signal/signalProvider.tsx
@@ -1,7 +1,6 @@
 // lib/signal/SignalProvider.tsx
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { PersistentSignalStore } from './PersistentSignalStore'; // <-- you'll need to define this
-import { SignalStore } from './SignalStore';
+import SignalStore from './SignalStore';
 
 const SignalContext = createContext<SignalStore | null>(null);
 
@@ -10,7 +9,7 @@ export const SignalProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     const init = async () => {
-      const store = await PersistentSignalStore.initFromStorage();
+      const store = await SignalStore.initFromStorage();
       setSignalStore(store);
     };
     init();

--- a/utils/signal/uploadKeyBundle.ts
+++ b/utils/signal/uploadKeyBundle.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabase';
+import { supabase } from '../../lib/supabase';
 
 export async function uploadKeyBundle(userId: string, publicBundle: any) {
   const { error } = await supabase


### PR DESCRIPTION
## Summary
- correct imports and exports across utils/signal modules
- provide helper functions and initialization utilities
- clean up provider/context usage

## Testing
- `npx tsc --noEmit` *(fails: cannot access registry and many missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d4244d8a08322a9ea330cc580e9e4