### PR TITLE
fix hermes utf16 crash

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,10 +16,11 @@ import 'react-native-get-random-values'; // ✅ Needed by libsignal
 global.Buffer = Buffer;
 global.process = process;
 
-// ✅ Optional: warn instead of crashing
+// Warn instead of crashing when libraries request utf‑16
 const originalFrom = Buffer.from.bind(Buffer);
 Buffer.from = ((data: any, encoding?: BufferEncoding) => {
-  if (encoding === 'utf-16le') {
+  const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
+  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') {
     console.warn('⚠️ utf-16le is not supported in Hermes — falling back to utf-8');
     encoding = 'utf-8';
   }
@@ -28,8 +29,9 @@ Buffer.from = ((data: any, encoding?: BufferEncoding) => {
 
 const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
 Buffer.isEncoding = (encoding: string): encoding is BufferEncoding => {
-  if (encoding === 'utf-16le') return false;
-  return originalIsEncoding(encoding);
+  const enc = encoding?.toLowerCase?.();
+  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
+  return originalIsEncoding(encoding as BufferEncoding);
 };
 
 

--- a/AuthPage.js
+++ b/AuthPage.js
@@ -1,8 +1,11 @@
 import { Buffer } from 'buffer';
 
 const originalFrom = Buffer.from.bind(Buffer);
+const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
+
 Buffer.from = function (data, encoding) {
-  if (encoding === 'utf-16le') {
+  const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
+  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') {
     console.warn('❌ Hermes does NOT support utf-16le. Replacing with utf-8.');
     encoding = 'utf-8';
   }
@@ -10,7 +13,8 @@ Buffer.from = function (data, encoding) {
 };
 
 Buffer.isEncoding = function (encoding) {
-  if (encoding === 'utf-16le') return false;
+  const enc = encoding?.toLowerCase?.();
+  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
   return originalIsEncoding(encoding);
 };
 

--- a/index.ts
+++ b/index.ts
@@ -1,23 +1,24 @@
 import { Buffer } from 'buffer';
 
-// Patch Buffer.from
+// Patch Buffer.from early so libraries can't request unsupported encodings
 const originalFrom = Buffer.from.bind(Buffer);
 Buffer.from = function (data: any, encoding?: any) {
-  if (encoding === 'utf-16le') {
+  const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
+  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') {
     console.warn('🔥 Hermes blocked utf-16le — replacing with utf-8');
     encoding = 'utf-8';
   }
   return originalFrom(data, encoding);
 } as typeof Buffer.from;
 
-
-// Patch Buffer.isEncoding
+// Patch Buffer.isEncoding to advertise lack of utf‑16le support
 const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
-const patchedIsEncoding: (encoding: string) => encoding is BufferEncoding = function (
-  encoding
-): encoding is BufferEncoding {
-  if (encoding === 'utf-16le') return false;
-  return originalIsEncoding(encoding);
+const patchedIsEncoding: (encoding: string) => encoding is BufferEncoding = (
+  encoding,
+): encoding is BufferEncoding => {
+  const enc = encoding?.toLowerCase?.();
+  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
+  return originalIsEncoding(encoding as BufferEncoding);
 };
 
 Buffer.isEncoding = patchedIsEncoding;


### PR DESCRIPTION
## Summary
- patch global Buffer to fall back when libraries request unsupported UTF‑16 encodings
- fix `AuthPage` patch to use `originalIsEncoding`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e8235c2c483229e98730e8c4b6bab