### PR TITLE
Fix utf-16le encoding crash

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -27,12 +27,6 @@ Buffer.from = ((data: any, encoding?: BufferEncoding) => {
   return originalFrom(data, encoding as any);
 }) as typeof Buffer.from;
 
-const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
-Buffer.isEncoding = (encoding: string): encoding is BufferEncoding => {
-  const enc = encoding?.toLowerCase?.();
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
-  return originalIsEncoding(encoding as BufferEncoding);
-};
 
 
 export default function App() {

--- a/AuthPage.js
+++ b/AuthPage.js
@@ -1,7 +1,6 @@
 import { Buffer } from 'buffer';
 
 const originalFrom = Buffer.from.bind(Buffer);
-const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
 
 Buffer.from = function (data, encoding) {
   const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
@@ -12,11 +11,6 @@ Buffer.from = function (data, encoding) {
   return originalFrom(data, encoding);
 };
 
-Buffer.isEncoding = function (encoding) {
-  const enc = encoding?.toLowerCase?.();
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
-  return originalIsEncoding(encoding);
-};
 
 
 global.Buffer = Buffer;

--- a/index.ts
+++ b/index.ts
@@ -11,17 +11,6 @@ Buffer.from = function (data: any, encoding?: any) {
   return originalFrom(data, encoding);
 } as typeof Buffer.from;
 
-// Patch Buffer.isEncoding to advertise lack of utf‑16le support
-const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
-const patchedIsEncoding: (encoding: string) => encoding is BufferEncoding = (
-  encoding,
-): encoding is BufferEncoding => {
-  const enc = encoding?.toLowerCase?.();
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
-  return originalIsEncoding(encoding as BufferEncoding);
-};
-
-Buffer.isEncoding = patchedIsEncoding;
 
 // Make Buffer global
 global.Buffer = Buffer;


### PR DESCRIPTION
## Summary
- stop overriding `Buffer.isEncoding`
- keep `Buffer.from` shim that replaces `utf-16le` with `utf-8`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e859aa6a083228b8c0c6408a110bf