### PR TITLE
Fix utf-16le crash with buffer shim

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { Buffer } from 'buffer';
 import process from 'process';
+import './utils/bufferShim';
 
 import { AuthProvider } from './AuthContext';
 
@@ -13,26 +13,8 @@ import { SignalProvider } from './utils/signal/SignalContext'; // ✅ ADD THIS
 import 'react-native-get-random-values'; // ✅ Needed by libsignal
 
 
-global.Buffer = Buffer;
 global.process = process;
 
-// Warn instead of crashing when libraries request utf‑16
-const originalFrom = Buffer.from.bind(Buffer);
-Buffer.from = ((data: any, encoding?: BufferEncoding) => {
-  const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') {
-    console.warn('⚠️ utf-16le is not supported in Hermes — falling back to utf-8');
-    encoding = 'utf-8';
-  }
-  return originalFrom(data, encoding as any);
-}) as typeof Buffer.from;
-
-const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
-Buffer.isEncoding = (encoding: string): encoding is BufferEncoding => {
-  const enc = encoding?.toLowerCase?.();
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
-  return originalIsEncoding(encoding as BufferEncoding);
-};
 
 
 export default function App() {

--- a/AuthPage.js
+++ b/AuthPage.js
@@ -1,25 +1,5 @@
-import { Buffer } from 'buffer';
+import './utils/bufferShim';
 
-const originalFrom = Buffer.from.bind(Buffer);
-const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
-
-Buffer.from = function (data, encoding) {
-  const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') {
-    console.warn('❌ Hermes does NOT support utf-16le. Replacing with utf-8.');
-    encoding = 'utf-8';
-  }
-  return originalFrom(data, encoding);
-};
-
-Buffer.isEncoding = function (encoding) {
-  const enc = encoding?.toLowerCase?.();
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
-  return originalIsEncoding(encoding);
-};
-
-
-global.Buffer = Buffer;
 
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, TouchableOpacity, StyleSheet, Alert, Platform } from 'react-native';

--- a/index.ts
+++ b/index.ts
@@ -1,30 +1,5 @@
-import { Buffer } from 'buffer';
-
-// Patch Buffer.from early so libraries can't request unsupported encodings
-const originalFrom = Buffer.from.bind(Buffer);
-Buffer.from = function (data: any, encoding?: any) {
-  const enc = typeof encoding === 'string' ? encoding.toLowerCase() : encoding;
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') {
-    console.warn('🔥 Hermes blocked utf-16le — replacing with utf-8');
-    encoding = 'utf-8';
-  }
-  return originalFrom(data, encoding);
-} as typeof Buffer.from;
-
-// Patch Buffer.isEncoding to advertise lack of utf‑16le support
-const originalIsEncoding = Buffer.isEncoding.bind(Buffer);
-const patchedIsEncoding: (encoding: string) => encoding is BufferEncoding = (
-  encoding,
-): encoding is BufferEncoding => {
-  const enc = encoding?.toLowerCase?.();
-  if (enc === 'utf-16le' || enc === 'utf16le' || enc === 'ucs2') return false;
-  return originalIsEncoding(encoding as BufferEncoding);
-};
-
-Buffer.isEncoding = patchedIsEncoding;
-
-// Make Buffer global
-global.Buffer = Buffer;
+// Patch Buffer to avoid Hermes crashes on utf‑16 requests
+import './utils/bufferShim';
 
 
 

--- a/utils/bufferShim.ts
+++ b/utils/bufferShim.ts
@@ -1,0 +1,60 @@
+import { Buffer as NodeBuffer } from 'buffer';
+
+function patchEncoding(enc?: any): BufferEncoding | undefined {
+  const e = typeof enc === 'string' ? enc.toLowerCase() : enc;
+  return e === 'utf-16le' || e === 'utf16le' || e === 'ucs2' ? 'utf-8' : enc;
+}
+
+export function applyBufferShim() {
+  const Buf: typeof NodeBuffer = NodeBuffer;
+
+  const originalFrom = Buf.from.bind(Buf);
+  Buf.from = function (data: any, encoding?: any): Buffer {
+    encoding = patchEncoding(encoding);
+    return originalFrom(data, encoding as any);
+  } as typeof Buffer.from;
+
+  const originalAlloc = Buf.alloc.bind(Buf);
+  Buf.alloc = function (
+    size: number,
+    fill?: string | Buffer | number,
+    encoding?: any,
+  ): Buffer {
+    encoding = patchEncoding(encoding);
+    return originalAlloc(size, fill as any, encoding as any);
+  } as typeof Buffer.alloc;
+
+  const originalWrite = Buf.prototype.write;
+  Buf.prototype.write = function (
+    string: string,
+    offset?: number | string,
+    length?: number,
+    encoding?: any,
+  ): any {
+    if (typeof offset === 'string') {
+      encoding = patchEncoding(offset);
+      return originalWrite.call(this, string, encoding as any);
+    }
+    encoding = patchEncoding(encoding);
+    return originalWrite.call(
+      this,
+      string,
+      offset as number | undefined,
+      length as number | undefined,
+      encoding as any,
+    );
+  };
+
+  const originalIsEncoding = Buf.isEncoding.bind(Buf);
+  Buf.isEncoding = function (encoding: string): encoding is BufferEncoding {
+    const enc = patchEncoding(encoding);
+    if (enc === 'utf-8') return true;
+    return originalIsEncoding(encoding as BufferEncoding);
+  };
+
+  // expose globally
+  global.Buffer = Buf as any;
+}
+
+// Apply immediately when this module is imported
+applyBufferShim();


### PR DESCRIPTION
## Summary
- centralize buffer shim in `utils/bufferShim.ts`
- import buffer shim early in `index.ts`, `App.tsx`, and `AuthPage.js`
- remove old ad‑hoc buffer overrides

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e859aa6a083228b8c0c6408a110bf