### PR TITLE
Add Signal identity key generation

### DIFF
--- a/AuthContext.tsx
+++ b/AuthContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { User } from '@supabase/supabase-js';
 import { supabase } from './lib/supabase';
+import { getOrCreateIdentity } from './lib/signal';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { postEvents } from './app/postEvents';
 import { likeEvents } from './app/likeEvents';
@@ -229,6 +230,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // Create/load the profile so posts have the foreign key ready
       await ensureProfile(user);
+      await getOrCreateIdentity();
     }
 
     return { error };
@@ -265,6 +267,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (session) {
       setUser(session.user);
       await ensureProfile(session.user);
+      await getOrCreateIdentity();
 
       return { error: null };
     }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql` **and** `sql/marketplace.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql`, `sql/marketplace.sql` **and** `sql/signal_identities.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
 
 
 
@@ -11,7 +11,7 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 
 
 4. Copy your project's URL and `anon` key into `lib/supabase.js`.
-5. Install dependencies with `npm install`.
+5. Install dependencies with `npm install` to pull in the Signal protocol library and secure storage.
 6. Add your logo image as `assets/AppIcon.png` to show it on startup.
 
 

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -1,0 +1,43 @@
+import * as SecureStore from 'expo-secure-store';
+import { KeyHelper } from '@privacyresearch/libsignal-protocol';
+import { supabase } from './supabase';
+
+const IDENTITY_KEY = 'signal_identity_key';
+const REGISTRATION_ID = 'signal_registration_id';
+
+export interface SignalIdentity {
+  identityKey: string;
+  registrationId: number;
+}
+
+export async function getOrCreateIdentity(): Promise<SignalIdentity> {
+  let encoded = await SecureStore.getItemAsync(IDENTITY_KEY);
+  let reg = await SecureStore.getItemAsync(REGISTRATION_ID);
+
+  if (!encoded || !reg) {
+    const identity = await KeyHelper.generateIdentityKeyPair();
+    const registrationId = KeyHelper.generateRegistrationId();
+
+    const pub = Buffer.from(identity.pubKey).toString('base64');
+    const priv = Buffer.from(identity.privKey).toString('base64');
+    encoded = JSON.stringify({ pub, priv });
+    reg = registrationId.toString();
+
+    await SecureStore.setItemAsync(IDENTITY_KEY, encoded);
+    await SecureStore.setItemAsync(REGISTRATION_ID, reg);
+
+    const user = supabase.auth.getUser ? (await supabase.auth.getUser()).data.user : supabase.auth.user();
+    if (user) {
+      await supabase
+        .from('signal_identities')
+        .upsert({
+          user_id: user.id,
+          identity_key: pub,
+          registration_id: registrationId,
+        }, { onConflict: 'user_id' });
+    }
+  }
+
+  const parsed = JSON.parse(encoded);
+  return { identityKey: parsed.pub, registrationId: parseInt(reg, 10) };
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "expo-file-system": "~18.1.10",
-    "expo-linear-gradient": "~14.1.5"
+    "expo-linear-gradient": "~14.1.5",
+    "expo-secure-store": "~12.4.0",
+    "@privacyresearch/libsignal-protocol": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/sql/signal_identities.sql
+++ b/sql/signal_identities.sql
@@ -1,0 +1,16 @@
+-- Store Signal protocol identity public keys
+create table if not exists public.signal_identities (
+    user_id uuid references public.profiles(id) on delete cascade primary key,
+    identity_key text not null,
+    registration_id integer not null,
+    created_at timestamptz not null default now()
+);
+
+alter table public.signal_identities enable row level security;
+
+create policy "Anyone can read signal identities" on public.signal_identities
+  for select using (true);
+create policy "Users can insert signal identity" on public.signal_identities
+  for insert with check (auth.uid() = user_id);
+create policy "Users can update their signal identity" on public.signal_identities
+  for update using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `expo-secure-store` and `@privacyresearch/libsignal-protocol`
- create `lib/signal.ts` for generating/storing Signal identity keys
- save identity public key to Supabase and added SQL for `signal_identities`
- call `getOrCreateIdentity` on sign in and sign up
- document the new SQL file and dependency installation in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68628fb931ac83229bf42452eecbe63a