### PR TITLE
Add Signal identity key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project uses [Supabase](https://supabase.com) for authentication and storing posts. Before running the app you need to configure your Supabase project.
 
 1. Create a new project in Supabase.
-2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql` **and** `sql/marketplace.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search.
+2. Open the SQL editor and run `sql/setup.sql`, `sql/profiles.sql`, `sql/likes.sql`, `sql/follows.sql`, `sql/videos.sql`, `sql/direct_messages.sql`, `sql/marketplace.sql` **and** `sql/signal.sql` from this repo. This creates the required tables (including nested replies) and row‑level security policies so posts persist across sessions and are visible to all users. The profiles script also adds `image_url` and `banner_url` columns so your avatar and banner images stay saved. Replies can be nested indefinitely by replying to any reply in the thread. The `likes` table with triggers keeps like counts in sync. The new `follows` table prevents duplicate follows and enforces that users can only follow on their own behalf. The `videos` table stores video URLs for the feed. The `marketplace` script sets up car listings and favorites so you can buy and sell vehicles. It also includes future‑proof fields like `is_boosted`, `views`, `favorites` and `search_index` for promoted listings and search. The `signal.sql` script sets up a table for storing public Signal keys used for encrypted direct messages.
 
 
 
@@ -18,6 +18,20 @@ This project uses [Supabase](https://supabase.com) for authentication and storin
 With the database configured you can run `npm start` to launch the Expo app.
 
 The marketplace screens live under `app/screens` and use a dark theme. The primary background color is `#2c2c54` and interactive elements use the accent color `#0070f3`.
+
+## Encrypted direct messages
+
+This project now includes a basic integration with the Signal protocol. Run the new `sql/signal.sql` script to create a table where each user can store their public Signal keys. Identity keys and prekeys are generated on device using the helper in `lib/signal.ts` and only the public parts are uploaded to Supabase.
+
+To generate an identity key pair you can do:
+
+```ts
+import { generateSignalIdentity } from '../lib/signal';
+
+const { identityKeyPair, registrationId } = await generateSignalIdentity();
+```
+
+The public values should then be encoded with `encodeKey` and saved to Supabase under the `signal_keys` table.
 
 The Market home screen includes a magnifying glass icon in the header. Tapping it reveals a search field for quickly filtering car listings by title or description. Results update live using a fuzzy, case-insensitive query against Supabase.
 

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -1,0 +1,21 @@
+import { KeyHelper } from '@privacyresearch/libsignal-protocol-typescript';
+import { Buffer } from 'buffer';
+
+export interface SignalIdentity {
+  identityKeyPair: KeyPair;
+  registrationId: number;
+}
+
+export interface KeyPair {
+  pubKey: ArrayBuffer;
+  privKey: ArrayBuffer;
+}
+
+export const generateSignalIdentity = async (): Promise<SignalIdentity> => {
+  const identityKeyPair = await KeyHelper.generateIdentityKeyPair();
+  const registrationId = await KeyHelper.generateRegistrationId();
+  return { identityKeyPair, registrationId };
+};
+
+export const encodeKey = (buf: ArrayBuffer): string =>
+  Buffer.from(new Uint8Array(buf)).toString('base64');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "expo-file-system": "~18.1.10",
-    "expo-linear-gradient": "~14.1.5"
+    "expo-linear-gradient": "~14.1.5",
+    "@privacyresearch/libsignal-protocol-typescript": "^0.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/sql/signal.sql
+++ b/sql/signal.sql
@@ -1,0 +1,14 @@
+-- Tables for storing Signal public keys
+create table if not exists public.signal_keys (
+  user_id uuid primary key references public.profiles(id) on delete cascade,
+  identity_key text not null,
+  registration_id integer not null,
+  pre_key_id integer not null,
+  pre_key text not null,
+  signed_pre_key_id integer not null,
+  signed_pre_key text not null
+);
+
+alter table public.signal_keys enable row level security;
+create policy "Users manage their signal keys" on public.signal_keys
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `lib/signal.ts` with helpers for generating Signal identity keys
- include new `@privacyresearch/libsignal-protocol-typescript` dependency
- add `sql/signal.sql` script for storing public Signal keys
- document Signal setup and usage in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686295d7a3cc8322863e3bea7fe08b59