### PR TITLE
Fix notifications when liking or replying

### DIFF
--- a/app/components/FollowButton.tsx
+++ b/app/components/FollowButton.tsx
@@ -62,7 +62,6 @@ export default function FollowButton({ targetUserId, onToggle }: FollowButtonPro
         followEvents.emit('followChanged', { targetUserId, following: true });
         createNotification(
           targetUserId,
-          user.id,
           'follow',
           null,
           `➕ ${user.user_metadata?.username || user.email} followed you`,

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -189,7 +189,6 @@ function PostCard({
               const sender = profile?.username || profile?.name || 'Someone';
               createNotification(
                 post.user_id,
-                user.id,
                 'like',
                 post.id,
                 `\uD83D\uDD34 ${sender} liked your post`,

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -247,7 +247,6 @@ const HomeScreen = forwardRef<HomeScreenRef, { hideInput?: boolean }>(
         const sender = profile.name || profile.username;
         createNotification(
           post.user_id,
-          profile.id,
           'reply',
           activePostId,
           `\uD83D\uDCAC ${sender} replied to your post`,

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -577,7 +577,6 @@ export default function PostDetailScreen() {
         const sender = profile.name || profile.username;
         createNotification(
           recipientId,
-          user.id,
           'reply',
           quickReplyTarget.parentId ?? post.id,
           `\uD83D\uDCAC ${sender} replied to your ${quickReplyTarget.parentId ? 'reply' : 'post'}`,

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -361,7 +361,6 @@ export default function ProfileScreen() {
         const sender = profile.name || profile.username;
         createNotification(
           post.user_id,
-          profile.id,
           'reply',
           activePostId,
           `\uD83D\uDCAC ${sender} replied to your post`,

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -562,7 +562,6 @@ export default function ReplyDetailScreen() {
         const sender = profile.name || profile.username;
         createNotification(
           recipientId,
-          user.id,
           'reply',
           quickReplyTarget.parentId ?? quickReplyTarget.postId,
           `\uD83D\uDCAC ${sender} replied to your ${quickReplyTarget.parentId ? 'reply' : 'post'}`,


### PR DESCRIPTION
## Summary
- fix usage of `createNotification` helper
- ensure notifications store correct sender when liking or replying

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68655602d4b08322ae420e36019d658d