### PR TITLE
Fix missing stack navigator

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -15,16 +15,13 @@ export default function Navigator() {
 
   return (
     <Suspense fallback={<LoadingScreen />}>
-      
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
         {user ? (
-          <>
-            <Stack.Screen name="Main" component={BottomTabsNavigator} />
-          </>
+          <Stack.Screen name="Main" component={BottomTabsNavigator} />
         ) : (
           <Stack.Screen name="Auth" component={AuthPage} />
         )}
-
-      
+      </Stack.Navigator>
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- fix missing `Stack.Navigator` wrapper in `Navigator` so login screen renders

## Testing
- `npm run test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: numerous missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686792188e448322bf1a28d494839d33