### PR TITLE
Fix missing stack navigator

### DIFF
--- a/Navigator.tsx
+++ b/Navigator.tsx
@@ -15,16 +15,13 @@ export default function Navigator() {
 
   return (
     <Suspense fallback={<LoadingScreen />}>
-      
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
         {user ? (
-          <>
-            <Stack.Screen name="Main" component={BottomTabsNavigator} />
-          </>
+          <Stack.Screen name="Main" component={BottomTabsNavigator} />
         ) : (
           <Stack.Screen name="Auth" component={AuthPage} />
         )}
-
-      
+      </Stack.Navigator>
     </Suspense>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "react-native": "0.79.2",
         "react-native-pager-view": "^6.7.1",
         "react-native-safe-area-context": "5.4.0",
-        "react-native-screens": "~4.10.0",
+        "react-native-screens": "~4.20.1",
         "react-native-tab-view": "^4.0.12",
         "react-native-video": "^6.1.0",
         "stream-browserify": "^3.0.0",
@@ -7804,8 +7804,8 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.10.0.tgz",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.20.1.tgz",
       "integrity": "sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-native": "0.79.2",
     "react-native-pager-view": "^6.7.1",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.20.1",
     "react-native-tab-view": "^4.0.12",
     "react-native-video": "^6.1.0",
     "stream-browserify": "^3.0.0",


### PR DESCRIPTION
## Summary
- fix missing `Stack.Navigator` wrapper in `Navigator` so login screen renders
- bump `react-native-screens` to avoid state update inside `useInsertionEffect`

## Testing
- `npm run test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: numerous missing type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_686792188e448322bf1a28d494839d33