### PR TITLE
Enable realtime notifications for likes

### DIFF
--- a/app/contexts/NotificationContext.tsx
+++ b/app/contexts/NotificationContext.tsx
@@ -40,6 +40,19 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     fetchNotifications();
   }, [fetchNotifications]);
 
+  useEffect(() => {
+    if (!user) return;
+    const subscription = supabase
+      .from(`notifications:user_id=eq.${user.id}`)
+      .on('INSERT', payload => {
+        setNotifications(prev => [payload.new as Notification, ...prev]);
+      })
+      .subscribe();
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [user?.id]);
+
   const addNotification = useCallback(
     async (userId: string, message: string) => {
       const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- subscribe to Supabase realtime for notification inserts

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'expo' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6867ccb4ca70832281e8365d6559f4a0