### PR TITLE
Enable realtime notifications for likes

### DIFF
--- a/app/components/MediaPostCard.tsx
+++ b/app/components/MediaPostCard.tsx
@@ -18,6 +18,8 @@ import { colors } from '../styles/colors';
 import useLike from '../hooks/useLike';
 import { Post } from './PostCard';
 import ReplyModal from './ReplyModal';
+import { useNotifications } from '../contexts/NotificationContext';
+import { useAuth } from '../../AuthContext';
 
 interface Props {
   post: Post;
@@ -31,6 +33,8 @@ export default function MediaPostCard({ post, avatarUri, isActive }: Props) {
   const username = post.profiles?.username || post.username || 'unknown';
   const [quickReplyVisible, setQuickReplyVisible] = useState(false);
   const navigation = useNavigation<any>();
+  const { addNotification } = useNotifications();
+  const { profile } = useAuth()!;
 
 
   const handleQuickReplySubmit = (
@@ -101,7 +105,16 @@ export default function MediaPostCard({ post, avatarUri, isActive }: Props) {
         </View>
       </View>
       <View style={styles.bottomLeft} pointerEvents="box-none">
-        <TouchableOpacity onPress={() => toggleLike()} style={{ marginRight: 4 }}>
+        <TouchableOpacity
+          onPress={() => {
+            if (!liked && profile && post.user_id !== profile.id) {
+              const username = profile.username || 'Someone';
+              addNotification(post.user_id, `${username} liked your post`);
+            }
+            toggleLike();
+          }}
+          style={{ marginRight: 4 }}
+        >
           <Ionicons
             name={liked ? 'heart' : 'heart-outline'}
             size={28}

--- a/app/contexts/NotificationContext.tsx
+++ b/app/contexts/NotificationContext.tsx
@@ -40,6 +40,19 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     fetchNotifications();
   }, [fetchNotifications]);
 
+  useEffect(() => {
+    if (!user) return;
+    const subscription = supabase
+      .from(`notifications:user_id=eq.${user.id}`)
+      .on('INSERT', payload => {
+        setNotifications(prev => [payload.new as Notification, ...prev]);
+      })
+      .subscribe();
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [user?.id]);
+
   const addNotification = useCallback(
     async (userId: string, message: string) => {
       const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- subscribe to Supabase realtime for notification inserts
- send a notification when liking media posts

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'expo' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6867ccb4ca70832281e8365d6559f4a0