### PR TITLE
Implement notifications system actions

### DIFF
--- a/app/components/MediaPostCard.tsx
+++ b/app/components/MediaPostCard.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 export default function MediaPostCard({ post, avatarUri, isActive }: Props) {
   const [modalVisible, setModalVisible] = useState(false);
-  const { likeCount, liked, toggleLike } = useLike(post.id);
+  const { likeCount, liked, toggleLike } = useLike(post.id, false, post.user_id);
   const username = post.profiles?.username || post.username || 'unknown';
   const [quickReplyVisible, setQuickReplyVisible] = useState(false);
   const navigation = useNavigation<any>();

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -82,7 +82,7 @@ function PostCard({
   const displayName = post.profiles?.name || post.profiles?.username || post.username;
   const userName = post.profiles?.username || post.username;
   const isReply = (post as any).post_id !== undefined;
-  const { likeCount, liked, toggleLike } = useLike(post.id, isReply);
+  const { likeCount, liked, toggleLike } = useLike(post.id, isReply, post.user_id);
   const { getStoriesForUser } = useStories();
   const hasStory = getStoriesForUser(post.user_id).length > 0;
 

--- a/app/hooks/useLike.ts
+++ b/app/hooks/useLike.ts
@@ -1,9 +1,13 @@
 import { usePostStore } from '../contexts/PostStoreContext';
 
-export default function useLike(id: string, isReply: boolean = false) {
+export default function useLike(
+  id: string,
+  isReply: boolean = false,
+  ownerId?: string,
+) {
   const { posts, toggleLike } = usePostStore();
   const likeCount = posts[id]?.likeCount ?? 0;
   const liked = posts[id]?.liked ?? false;
-  return { likeCount, liked, toggleLike: () => toggleLike(id, isReply) };
+  return { likeCount, liked, toggleLike: () => toggleLike(id, isReply, ownerId) };
 }
 

--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -20,6 +20,7 @@ import { useRoute, useNavigation } from '@react-navigation/native';
 
 import { supabase, REPLY_VIDEO_BUCKET } from '../../lib/supabase';
 import { uploadImage } from '../../lib/uploadImage';
+import { createNotification } from '../../lib/supabase/notifications';
 import { getLikeCounts } from '../../lib/getLikeCounts';
 import { useAuth } from '../../AuthContext';
 import { colors } from '../styles/colors';
@@ -539,6 +540,21 @@ export default function PostDetailScreen() {
     }
 
     if (!error && data) {
+      const targetId = quickReplyTarget.parentId
+        ? allReplies.find(r => r.id === quickReplyTarget.parentId)?.user_id
+        : post.user_id;
+      if (targetId && targetId !== user.id) {
+        await createNotification({
+          user_id: targetId,
+          sender_id: user.id,
+          recipient_id: targetId,
+          type: 'reply',
+          entity_id: data.id,
+          message: `${profile.name || profile.username} replied to your ${
+            quickReplyTarget.parentId ? 'reply' : 'post'
+          }`,
+        });
+      }
       if (quickReplyTarget.parentId === null) {
         setReplies(prev =>
           prev.map(r =>

--- a/lib/supabase/notifications.ts
+++ b/lib/supabase/notifications.ts
@@ -31,3 +31,16 @@ export async function fetchNotifications(userId: string) {
 export async function markNotificationRead(id: string) {
   return supabase.from('notifications').update({ read: true }).eq('id', id);
 }
+
+export interface NewNotification {
+  user_id: string;
+  sender_id: string | null;
+  recipient_id: string | null;
+  type: string;
+  entity_id: string | null;
+  message: string;
+}
+
+export async function createNotification(payload: NewNotification) {
+  return supabase.from('notifications').insert(payload);
+}


### PR DESCRIPTION
## Summary
- integrate notification API to create like and reply notifications
- expose helper to create notifications in supabase lib
- update PostStore like handler to send notifications
- add owner context to like hooks and components
- notify post/reply owners when replies are added

## Testing
- `npx tsc -p tsconfig.json` *(fails: expo base config missing)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686917f403fc832281704683852650d3