### PR TITLE
Enable media post comment notifications

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -30,6 +30,7 @@ import { postEvents } from '../postEvents';
 import PostCard, { Post } from '../components/PostCard';
 import { CONFIRM_ACTION } from '../constants/ui';
 import ReplyModal from '../components/ReplyModal';
+import { insertNotification } from '../../lib/supabase/notifications';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -564,6 +565,21 @@ export default function PostDetailScreen() {
         return counts;
       });
       initialize([{ id: data.id, like_count: 0 }]);
+
+      if (
+        quickReplyTarget.parentId === null &&
+        (post.image_url || post.video_url) &&
+        profile.id !== post.user_id
+      ) {
+        const username = profile.username || 'Someone';
+        await insertNotification({
+          sender_id: profile.id,
+          recipient_id: post.user_id,
+          type: 'reply',
+          entity_id: post.id,
+          message: `${username} replied to your post`,
+        });
+      }
     }
     fetchReplies();
   };

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -32,6 +32,7 @@ import useLike from '../hooks/useLike';
 import { postEvents } from '../postEvents';
 import { CONFIRM_ACTION } from '../constants/ui';
 import ReplyModal from '../components/ReplyModal';
+import { insertNotification } from '../../lib/supabase/notifications';
 
 
 const CHILD_PREFIX = 'cached_child_replies_';
@@ -571,6 +572,23 @@ export default function ReplyDetailScreen() {
         return counts;
       });
       initialize([{ id: data.id, like_count: 0 }]);
+
+      if (
+        (quickReplyTarget.parentId === originalPost?.id ||
+          quickReplyTarget.parentId === null) &&
+        originalPost &&
+        (originalPost.image_url || originalPost.video_url) &&
+        profile.id !== originalPost.user_id
+      ) {
+        const username = profile.username || 'Someone';
+        await insertNotification({
+          sender_id: profile.id,
+          recipient_id: originalPost.user_id,
+          type: 'reply',
+          entity_id: originalPost.id,
+          message: `${username} replied to your post`,
+        });
+      }
     }
     fetchReplies();
   };


### PR DESCRIPTION
## Summary
- notify media post owners when replies are made
- support comment notifications from Home, Post detail, and Reply detail screens

## Testing
- `npm test` *(fails: Missing script and blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_686a59510c548322ab7694aa6ea1b295