### PR TITLE
Implement reply notifications

### DIFF
--- a/app/screens/PostDetailScreen.tsx
+++ b/app/screens/PostDetailScreen.tsx
@@ -30,6 +30,7 @@ import { postEvents } from '../postEvents';
 import PostCard, { Post } from '../components/PostCard';
 import { CONFIRM_ACTION } from '../constants/ui';
 import ReplyModal from '../components/ReplyModal';
+import { insertNotification } from '../../lib/supabase/notifications';
 
 const REPLY_STORAGE_PREFIX = 'cached_replies_';
 const COUNT_STORAGE_KEY = 'cached_reply_counts';
@@ -564,6 +565,15 @@ export default function PostDetailScreen() {
         return counts;
       });
       initialize([{ id: data.id, like_count: 0 }]);
+      if (user.id !== post.user_id) {
+        await insertNotification({
+          sender_id: user.id,
+          recipient_id: post.user_id,
+          entity_id: data.id,
+          type: 'reply',
+          message: `@${profile.username} replied to your post`,
+        });
+      }
     }
     fetchReplies();
   };

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -37,6 +37,7 @@ import ReplyThread from '../components/ReplyThread';
 
 import { replyEvents } from '../replyEvents';
 import { likeEvents } from '../likeEvents';
+import { insertNotification } from '../../lib/supabase/notifications';
 
 import { CONFIRM_ACTION } from '../constants/ui';
 
@@ -355,6 +356,16 @@ export default function ProfileScreen() {
       });
       initialize([{ id: data.id, like_count: 0 }]);
       replyEvents.emit('replyAdded', activePostId);
+      const targetPost = posts.find(p => p.id === activePostId);
+      if (targetPost && targetPost.user_id !== profile.id) {
+        await insertNotification({
+          sender_id: profile.id,
+          recipient_id: targetPost.user_id,
+          entity_id: data.id,
+          type: 'reply',
+          message: `@${profile.username} replied to your post`,
+        });
+      }
     } else if (error) {
       console.error('Reply failed', error.message);
     }

--- a/app/screens/ReplyDetailScreen.tsx
+++ b/app/screens/ReplyDetailScreen.tsx
@@ -32,6 +32,7 @@ import useLike from '../hooks/useLike';
 import { postEvents } from '../postEvents';
 import { CONFIRM_ACTION } from '../constants/ui';
 import ReplyModal from '../components/ReplyModal';
+import { insertNotification } from '../../lib/supabase/notifications';
 
 
 const CHILD_PREFIX = 'cached_child_replies_';
@@ -571,6 +572,15 @@ export default function ReplyDetailScreen() {
         return counts;
       });
       initialize([{ id: data.id, like_count: 0 }]);
+      if (originalPost && user.id !== originalPost.user_id) {
+        await insertNotification({
+          sender_id: user.id,
+          recipient_id: originalPost.user_id,
+          entity_id: data.id,
+          type: 'reply',
+          message: `@${profile.username} replied to your post`,
+        });
+      }
     }
     fetchReplies();
   };


### PR DESCRIPTION
## Summary
- extend notifications to fire on replies
- insert notifications after creating replies
- subscribe to reply notifications on the client

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a7615a69083229a01860c1a7083d4