### PR TITLE
Add self-contained chat keygen module

### DIFF
--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -1,34 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
-import { useAuth } from '../../AuthContext';
-import { getOrCreateChatKeys } from '../../lib/chatKeys';
-
+import { getOrCreateKeys } from './lib/keygen';
 
 export default function ChatScreen() {
-  console.log('🟢 ChatScreen mounted');
-
-  const { user } = useAuth()!;
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
     const init = async () => {
-      if (!user) return;
-      console.log('🧠 Running getOrCreateChatKeys for:', user?.id);
-
-      await getOrCreateChatKeys(user.id);
-
+      console.log('🟢 ChatScreen mounted');
+      const keys = await getOrCreateKeys();
+      console.log('🔑 Key status:', keys ? 'loaded' : 'failed');
       if (isMounted) setReady(true);
     };
     init();
     return () => {
       isMounted = false;
     };
-  }, [user?.id]);
+  }, []);
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      {ready && <Text>🔐 E2EE Chat Ready</Text>}
+      {ready && <Text>🔐 E2EE Ready</Text>}
     </View>
   );
 }

--- a/app/chat/lib/crypto.ts
+++ b/app/chat/lib/crypto.ts
@@ -1,0 +1,20 @@
+import * as nacl from 'tweetnacl';
+import * as util from 'tweetnacl-util';
+
+export function encryptMessage(message: string, receiverPublicKey: Uint8Array, senderSecretKey: Uint8Array) {
+  const nonce = nacl.randomBytes(nacl.box.nonceLength);
+  const msg = util.decodeUTF8(message);
+  const box = nacl.box(msg, nonce, receiverPublicKey, senderSecretKey);
+  return {
+    nonce: util.encodeBase64(nonce),
+    box: util.encodeBase64(box),
+  };
+}
+
+export function decryptMessage(boxB64: string, nonceB64: string, senderPublicKey: Uint8Array, receiverSecretKey: Uint8Array) {
+  const box = util.decodeBase64(boxB64);
+  const nonce = util.decodeBase64(nonceB64);
+  const msg = nacl.box.open(box, nonce, senderPublicKey, receiverSecretKey);
+  if (!msg) throw new Error('Failed to decrypt');
+  return util.encodeUTF8(msg);
+}

--- a/app/chat/lib/keygen.ts
+++ b/app/chat/lib/keygen.ts
@@ -1,0 +1,57 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as nacl from 'tweetnacl';
+import * as util from 'tweetnacl-util';
+import { supabase } from './supabase';
+
+const STORAGE_KEY = 'e2ee_keypair';
+
+export interface KeyPair {
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+}
+
+export async function getOrCreateKeys(): Promise<KeyPair> {
+  console.log('[keygen] Checking for existing keypair');
+  const stored = await AsyncStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      console.log('[keygen] Loaded keypair from storage');
+      return {
+        publicKey: util.decodeBase64(parsed.publicKey),
+        secretKey: util.decodeBase64(parsed.secretKey),
+      };
+    } catch (err) {
+      console.log('[keygen] Failed to parse stored keypair', err);
+    }
+  }
+
+  console.log('[keygen] Generating new keypair');
+  const kp = nacl.box.keyPair();
+  const publicKeyB64 = util.encodeBase64(kp.publicKey);
+  const secretKeyB64 = util.encodeBase64(kp.secretKey);
+
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ publicKey: publicKeyB64, secretKey: secretKeyB64 }));
+  console.log('[keygen] Stored new keypair locally');
+
+  try {
+    const { data: userData } = await supabase.auth.getUser();
+    const userId = userData.user?.id;
+    if (userId) {
+      const { error } = await supabase
+        .from('user_keys')
+        .upsert({ user_id: userId, public_key: publicKeyB64 }, { onConflict: 'user_id' });
+      if (error) {
+        console.error('[keygen] Failed to upload public key', error);
+      } else {
+        console.log('[keygen] Uploaded public key for', userId);
+      }
+    } else {
+      console.warn('[keygen] No authenticated user - skipping upload');
+    }
+  } catch (err) {
+    console.error('[keygen] Error uploading public key', err);
+  }
+
+  return kp;
+}

--- a/app/chat/lib/supabase.ts
+++ b/app/chat/lib/supabase.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const SUPABASE_URL = 'https://yfiynxfsvpklremperpg.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaXlueGZzdnBrbHJlbXBlcnBnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY4MTEzNTYsImV4cCI6MjA2MjM4NzM1Nn0.1sLJqsSwKKrUuJS6ln4UFoNCBssFlhGisZCsSt09x5o';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    storage: AsyncStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});


### PR DESCRIPTION
## Summary
- implement `getOrCreateKeys` for E2EE chat key management
- add simple encrypt/decrypt helpers
- create local Supabase client for chat module
- initialize keys from `ChatScreen` and log status

## Testing
- `npx tsc --noEmit` *(fails: expo/tsconfig.base not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be875fa6c83229df7accb07e1dc82