### PR TITLE
Implement encryptMessage NaCl helper

### DIFF
--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -1,5 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams } from 'expo-router';
 import { useAuth } from '../../AuthContext';
 import { getOrCreateChatKeys } from '../../lib/chatKeys';
 
@@ -8,7 +18,9 @@ export default function ChatScreen() {
   console.log('🟢 ChatScreen mounted');
 
   const { user } = useAuth()!;
+  const { recipientId } = useLocalSearchParams<{ recipientId?: string }>();
   const [ready, setReady] = useState(false);
+  const [text, setText] = useState('');
 
   useEffect(() => {
     let isMounted = true;
@@ -26,9 +38,64 @@ export default function ChatScreen() {
     };
   }, [user?.id]);
 
+  const handleSend = () => {
+    const body = text.trim();
+    if (!body || !recipientId) return;
+    onSend(body, String(recipientId));
+    setText('');
+  };
+
+  const onSend = (message: string, toId: string) => {
+    console.log('Send encrypted message', message, 'to', toId);
+  };
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      {ready && <Text>🔐 E2EE Chat Ready</Text>}
-    </View>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={80}
+    >
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        {ready && <Text>🔐 E2EE Chat Ready</Text>}
+      </View>
+      <View style={styles.inputBar}>
+        <TextInput
+          value={text}
+          onChangeText={setText}
+          placeholder="Message"
+          style={styles.input}
+          placeholderTextColor="#999"
+        />
+        <TouchableOpacity onPress={handleSend} style={styles.sendButton}>
+          <Ionicons name="send" size={20} color="#fff" />
+        </TouchableOpacity>
+      </View>
+    </KeyboardAvoidingView>
   );
 }
+
+const styles = StyleSheet.create({
+  inputBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 8,
+    backgroundColor: '#f2f2f2',
+  },
+  input: {
+    flex: 1,
+    backgroundColor: '#fff',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 20,
+    marginRight: 8,
+  },
+  sendButton: {
+    backgroundColor: '#007aff',
+    padding: 10,
+    borderRadius: 20,
+  },
+});

--- a/lib/encryptMessage.ts
+++ b/lib/encryptMessage.ts
@@ -1,0 +1,40 @@
+import 'react-native-get-random-values';
+import * as nacl from 'tweetnacl';
+import * as naclUtil from 'tweetnacl-util';
+
+export interface EncryptMessageOptions {
+  plaintext: string;
+  senderSecretKey: Uint8Array;
+  recipientPublicKey: Uint8Array;
+}
+
+export interface EncryptedMessage {
+  ciphertext: string;
+  nonce: string;
+}
+
+/**
+ * Encrypt a plaintext message using NaCl box.
+ *
+ * @param options Object containing plaintext, senderSecretKey and recipientPublicKey.
+ * @returns Base64 encoded ciphertext and nonce.
+ */
+export function encryptMessage(options: EncryptMessageOptions): EncryptedMessage {
+  const { plaintext, senderSecretKey, recipientPublicKey } = options;
+
+  // Generate a random nonce
+  const nonce = nacl.randomBytes(24);
+
+  // Encode the plaintext
+  const messageUint8 = naclUtil.decodeUTF8(plaintext);
+
+  // Encrypt the message
+  const encrypted = nacl.box(messageUint8, nonce, recipientPublicKey, senderSecretKey);
+
+  // Encode ciphertext and nonce to base64
+  const ciphertext = naclUtil.encodeBase64(encrypted);
+  const nonceB64 = naclUtil.encodeBase64(nonce);
+
+  return { ciphertext, nonce: nonceB64 };
+}
+


### PR DESCRIPTION
## Summary
- add utility to encrypt messages with tweetnacl
- create a floating message input for chat screen

## Testing
- `npm test` *(fails: Missing script and blocked network)*


------
https://chatgpt.com/codex/tasks/task_e_686e6d97fe5083229b8d257828127f6b