### PR TITLE
Add DM list refresh and timestamps in chat

### DIFF
--- a/app/screens/DMThreadScreen.tsx
+++ b/app/screens/DMThreadScreen.tsx
@@ -115,11 +115,12 @@ export default function DMThreadScreen() {
     const senderName = isMe
       ? 'You'
       : profile?.name || profile?.username || 'Unknown';
+    const time = new Date(item.created_at).toLocaleTimeString();
     return (
       <View style={[styles.messageRow, isMe ? styles.right : styles.left]}>
         <Text style={styles.sender}>{senderName}</Text>
-
         <Text style={styles.messageText}>{item.text}</Text>
+        <Text style={styles.time}>{time}</Text>
       </View>
     );
   };
@@ -193,6 +194,7 @@ const styles = StyleSheet.create({
   right: { alignSelf: 'flex-end', backgroundColor: colors.accent },
   messageText: { color: colors.text },
   sender: { color: colors.muted, fontSize: 12, marginBottom: 2 },
+  time: { color: colors.muted, fontSize: 10, marginTop: 2, alignSelf: 'flex-end' },
 
   inputRow: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- reload DM list whenever the screen is focused so new conversations appear
- show timestamps on each message bubble in a DM thread for context

## Testing
- `npx tsc -p tsconfig.json` *(fails: expo/tsconfig.base not found and missing React Native types)*

------
https://chatgpt.com/codex/tasks/task_e_6877b7811e94832280d12e670b22c23b