### PR TITLE
Implement ChatScreen for DMs

### DIFF
--- a/app/screens/ChatScreen.tsx
+++ b/app/screens/ChatScreen.tsx
@@ -1,0 +1,201 @@
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  Dimensions,
+} from 'react-native';
+import { useRoute } from '@react-navigation/native';
+import { supabase } from '../../lib/supabase';
+import { useAuth } from '../../AuthContext';
+import { colors } from '../styles/colors';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+const BOTTOM_NAV_HEIGHT = SCREEN_HEIGHT * 0.1;
+const INPUT_BAR_HEIGHT = 56;
+
+interface Message {
+  id: string;
+  sender_id: string;
+  receiver_id: string;
+  content: string;
+  created_at: string;
+}
+
+interface Params {
+  id: string;
+  display_name?: string | null;
+  avatar_url?: string | null;
+}
+
+export default function ChatScreen() {
+  const route = useRoute<any>();
+  const { id: otherId, display_name, avatar_url } = route.params as Params;
+  const { user } = useAuth()!;
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [text, setText] = useState('');
+  const flatRef = useRef<FlatList>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchMessages = async () => {
+      if (!user) return;
+      const { data, error } = await supabase
+        .from('messages')
+        .select('*')
+        .or(`and(sender_id.eq.${user.id},receiver_id.eq.${otherId}),and(sender_id.eq.${otherId},receiver_id.eq.${user.id})`)
+        .order('created_at');
+      if (error) console.error('Failed to fetch messages', error);
+      if (isMounted) setMessages((data ?? []) as Message[]);
+    };
+    fetchMessages();
+
+    const subscription = supabase
+      .from('messages')
+      .on('INSERT', (payload) => {
+        const msg = payload.new as Message;
+        if (
+          (msg.sender_id === user?.id && msg.receiver_id === otherId) ||
+          (msg.sender_id === otherId && msg.receiver_id === user?.id)
+        ) {
+          setMessages((m) => [...m, msg]);
+        }
+      })
+      .subscribe();
+
+    return () => {
+      isMounted = false;
+      supabase.removeSubscription(subscription);
+    };
+  }, [user, otherId]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      flatRef.current?.scrollToEnd({ animated: true });
+    }
+  }, [messages]);
+
+  const send = async () => {
+    const body = text.trim();
+    if (!body || !user) return;
+    setText('');
+    const { data, error } = await supabase
+      .from('messages')
+      .insert({ sender_id: user.id, receiver_id: otherId, content: body })
+      .select()
+      .single();
+    if (error) {
+      console.error('Failed to send message', error);
+      return;
+    }
+    if (data) {
+      setMessages((m) => [...m, data as Message]);
+    }
+  };
+
+  const renderItem = ({ item }: { item: Message }) => {
+    const isMe = item.sender_id === user?.id;
+    return (
+      <View style={[styles.messageRow, isMe ? styles.right : styles.left]}>
+        <Text style={styles.messageText}>{item.content}</Text>
+        <Text style={styles.time}>{new Date(item.created_at).toLocaleTimeString()}</Text>
+      </View>
+    );
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={BOTTOM_NAV_HEIGHT}
+    >
+      <View style={styles.header}>
+        {avatar_url ? (
+          <Image source={{ uri: avatar_url }} style={styles.avatar} />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        <Text style={styles.name}>{display_name}</Text>
+      </View>
+      <FlatList
+        ref={flatRef}
+        data={messages}
+        keyExtractor={(i) => i.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+      />
+      <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          value={text}
+          onChangeText={setText}
+          placeholder="Message"
+          placeholderTextColor={colors.muted}
+        />
+        <TouchableOpacity onPress={send} style={styles.sendButton}>
+          <Text style={styles.sendButtonText}>Send</Text>
+        </TouchableOpacity>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.muted,
+  },
+  avatar: { width: 36, height: 36, borderRadius: 18, marginRight: 8 },
+  placeholder: { backgroundColor: colors.muted },
+  name: { color: colors.text, fontSize: 16 },
+  list: { padding: 12, paddingBottom: INPUT_BAR_HEIGHT + 12 },
+  messageRow: {
+    maxWidth: '80%',
+    marginVertical: 4,
+    padding: 8,
+    borderRadius: 6,
+  },
+  left: { alignSelf: 'flex-start', backgroundColor: '#444' },
+  right: { alignSelf: 'flex-end', backgroundColor: '#2a8fff' },
+  messageText: { color: colors.text },
+  time: { color: colors.muted, fontSize: 10, marginTop: 2 },
+  inputRow: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: BOTTOM_NAV_HEIGHT,
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.muted,
+    backgroundColor: colors.background,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: '#1f1f3d',
+    color: colors.text,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  sendButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: colors.accent,
+    borderRadius: 6,
+  },
+  sendButtonText: { color: colors.text },
+});
+

--- a/app/screens/NewChatScreen.tsx
+++ b/app/screens/NewChatScreen.tsx
@@ -61,32 +61,16 @@ export default function NewChatScreen() {
     );
   });
 
-  const startChat = async (targetId: string) => {
-    if (!user) return;
-    const { data: existing } = await supabase
-      .from('conversations')
-      .select('*')
-      .or(`and(participant_1.eq.${user.id},participant_2.eq.${targetId}),and(participant_1.eq.${targetId},participant_2.eq.${user.id})`)
-      .maybeSingle();
-
-    let convoId = existing?.id;
-    if (!convoId) {
-      const { data: created, error } = await supabase
-        .from('conversations')
-        .insert({ participant_1: user.id, participant_2: targetId })
-        .select('id')
-        .single();
-      if (error) {
-        console.error('Failed to create conversation', error);
-        return;
-      }
-      convoId = created.id;
-    }
-    navigation.replace('DMThread', { conversationId: convoId, recipientId: targetId });
+  const startChat = (profile: Profile) => {
+    navigation.navigate('Chat', {
+      id: profile.id,
+      display_name: profile.name || profile.username,
+      avatar_url: profile.image_url,
+    });
   };
 
   const renderItem = ({ item }: { item: Profile }) => (
-    <TouchableOpacity style={styles.item} onPress={() => startChat(item.id)}>
+    <TouchableOpacity style={styles.item} onPress={() => startChat(item)}>
       {item.image_url ? (
         <Image source={{ uri: item.image_url }} style={styles.avatar} />
       ) : (

--- a/bottomtabs/BottomTabsNavigator.js
+++ b/bottomtabs/BottomTabsNavigator.js
@@ -45,6 +45,7 @@ const StoryViewScreen = React.lazy(() =>
 const DMListScreen = React.lazy(() => import('../app/screens/DMListScreen'));
 const NewChatScreen = React.lazy(() => import('../app/screens/NewChatScreen'));
 const DMThreadScreen = React.lazy(() => import('../app/screens/DMThreadScreen'));
+const ChatScreen = React.lazy(() => import('../app/screens/ChatScreen'));
 
 const { height } = Dimensions.get('window');
 
@@ -63,6 +64,7 @@ function HomeStackScreen() {
         <Stack.Screen name="StoryView" component={StoryViewScreen} />
         <Stack.Screen name="DMList" component={DMListScreen} />
         <Stack.Screen name="NewChat" component={NewChatScreen} />
+        <Stack.Screen name="Chat" component={ChatScreen} />
         <Stack.Screen name="DMThread" component={DMThreadScreen} />
 
       </Stack.Navigator>


### PR DESCRIPTION
## Summary
- create `ChatScreen` to display direct messages between two users
- add `ChatScreen` to navigation stack
- update user search screen to open `ChatScreen` when a user is tapped

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877fb469ad083228be3900bc2f0b5bf