### PR TITLE
Fix DM search bar placement

### DIFF
--- a/app/screens/NewChatScreen.tsx
+++ b/app/screens/NewChatScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, TextInput, Image, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../AuthContext';
@@ -15,13 +16,17 @@ interface Profile {
 export default function NewChatScreen() {
   const navigation = useNavigation<any>();
   const { user } = useAuth()!;
+  const insets = useSafeAreaInsets();
   const [allUsers, setAllUsers] = useState<Profile[]>([]);
   const [search, setSearch] = useState('');
+  const [searchResults, setSearchResults] = useState<Profile[]>([]);
 
   useEffect(() => {
     let isMounted = true;
     const load = async () => {
       if (!user) return;
+      console.log('NewChatScreen user effect', user.id);
+      console.log('Load follows for user', user.id);
       const { data: follows, error } = await supabase
         .from('follows')
         .select('following_id')
@@ -30,6 +35,7 @@ export default function NewChatScreen() {
         console.error('Failed to fetch follow list', error);
         return;
       }
+      console.log('Follow IDs', follows?.map((f: any) => f.following_id));
       const ids = (follows ?? []).map((f: any) => f.following_id);
       if (ids.length === 0) {
         if (isMounted) setAllUsers([]);
@@ -43,6 +49,7 @@ export default function NewChatScreen() {
         console.error('Failed to fetch users', profileError);
         return;
       }
+      console.log('Loaded profiles', profiles?.map((p) => p.id));
       if (isMounted)
         setAllUsers((profiles ?? []).filter((p) => p.id !== user.id) as Profile[]);
 
@@ -53,21 +60,52 @@ export default function NewChatScreen() {
     };
   }, [user]);
 
-  const filtered = allUsers.filter((u) => {
-    const query = search.toLowerCase();
-    return (
-      u.username?.toLowerCase().includes(query) ||
-      u.name?.toLowerCase().includes(query)
-    );
-  });
+  useEffect(() => {
+    let isMounted = true;
+    const run = async () => {
+      const q = search.trim();
+      if (q === '') {
+        if (isMounted) setSearchResults([]);
+        return;
+      }
+      console.log('Searching profiles for', q);
+      const like = `%${q}%`;
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, username, name, image_url')
+        .or(`username.ilike.${like},name.ilike.${like}`)
+        .limit(20);
+      if (error) {
+        console.error('Failed to search profiles', error);
+        if (isMounted) setSearchResults([]);
+        return;
+      }
+      if (isMounted) {
+        const results = (data ?? []).filter((p) => p.id !== user?.id) as Profile[];
+        console.log('Search results for', q, results.map((p) => p.id));
+        setSearchResults(results);
+      }
+    };
+    run();
+    return () => {
+      isMounted = false;
+    };
+  }, [search, user]);
+
+  const filtered = search.trim() === '' ? allUsers : searchResults;
 
   const startChat = async (targetId: string) => {
     if (!user) return;
+    console.log('startChat current user', user.id, 'target', targetId);
     const { data: existing } = await supabase
       .from('conversations')
       .select('*')
       .or(`and(participant_1.eq.${user.id},participant_2.eq.${targetId}),and(participant_1.eq.${targetId},participant_2.eq.${user.id})`)
       .maybeSingle();
+
+    if (existing) {
+      console.log('Found existing conversation', existing.id, existing.participant_1, existing.participant_2);
+    }
 
     let convoId = existing?.id;
     if (!convoId) {
@@ -80,8 +118,10 @@ export default function NewChatScreen() {
         console.error('Failed to create conversation', error);
         return;
       }
+      console.log('Created conversation', created.id);
       convoId = created.id;
     }
+    console.log('Navigating to DMThread', convoId);
     navigation.replace('DMThread', { conversationId: convoId, recipientId: targetId });
   };
 
@@ -97,7 +137,7 @@ export default function NewChatScreen() {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top + 16 }]}>
       <TextInput
         style={styles.input}
         placeholder="Search users"


### PR DESCRIPTION
## Summary
- improve DM NewChatScreen layout to avoid notch overlap
- query entire `profiles` table for DM user search if the query isn't empty
- log user IDs and conversation IDs while starting new chats

## Testing
- `npx tsc --noEmit` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a6cc874e4832286dcea01fd232030